### PR TITLE
Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Provides a PostgreSQL-based persistence for [Rebus](https://github.com/rebus-org
 * sagas
 * subscriptions
 * timeouts
+* transport
+
+Note:  In your npgsql connection string, if you are using the default settings, set your maximum pool size=30 to avoid connection pool starvation issues.
 
 ![](https://raw.githubusercontent.com/rebus-org/Rebus/master/artwork/little_rebusbus2_copy-200x200.png)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Provides a PostgreSQL-based persistence for [Rebus](https://github.com/rebus-org
 * timeouts
 * transport
 
-Note:  In your npgsql connection string, if you are using the default settings, set your maximum pool size=30 to avoid connection pool starvation issues.
+Note:  In your npgsql connection string, if you are using the default settings, set your maximum pool size=30 to avoid connection pool exhaustion issues.
 
 ![](https://raw.githubusercontent.com/rebus-org/Rebus/master/artwork/little_rebusbus2_copy-200x200.png)
 

--- a/Rebus.PostgreSql.Tests/Categories.cs
+++ b/Rebus.PostgreSql.Tests/Categories.cs
@@ -1,0 +1,7 @@
+﻿namespace Rebus.PostgreSql.Tests
+{
+    public class Categories
+    {
+        public const string PostgreSql = "PostgreSql";
+    }
+}

--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -41,7 +41,7 @@ namespace Rebus.PostgreSql.Tests
         static string GetConnectionStringForDatabase(string databaseName)
         {
             return Environment.GetEnvironmentVariable("REBUS_POSTGRES")
-                   ?? $"server=localhost; database={databaseName}; user id=postgres; password=postgres;";
+                   ?? $"server=localhost; database={databaseName}; user id=postgres; password=postgres;maximum pool size=30;";
         }
     }
 }

--- a/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
+++ b/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
@@ -80,7 +80,10 @@
     <Compile Include="PostgreSqlTestHelper.cs" />
     <Compile Include="TestCategory.cs" />
     <Compile Include="Timeouts\TestPostgreSqlTimeoutManager.cs" />
-    <Compile Include="Transport\SqlTransportFactory.cs" />
+    <Compile Include="Transport\TestPostgreSqlTransportReceivePerformance.cs" />
+    <Compile Include="Transport\PostgreSqlTransportTests.cs" />
+    <Compile Include="Transport\TestPostgreSqlTransport.cs" />
+    <Compile Include="Transport\TestPostgreSqlTransportCleanup.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
+++ b/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
@@ -42,8 +42,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Npgsql, Version=3.1.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.3.1.7\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.1.8.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.1.8\lib\net45\Npgsql.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
+++ b/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Categories.cs" />
     <Compile Include="Sagas\PostgreSqlBasicLoadAndSaveAndFindOperations.cs" />
     <Compile Include="Sagas\ConcurrencyHandling.cs" />
     <Compile Include="Sagas\PostgreSqlSagaSnapshotTest.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="PostgreSqlTestHelper.cs" />
     <Compile Include="TestCategory.cs" />
     <Compile Include="Timeouts\TestPostgreSqlTimeoutManager.cs" />
+    <Compile Include="Transport\SqlTransportFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Rebus.PostgreSql.Tests/Transport/PostgreSqlTransportTests.cs
+++ b/Rebus.PostgreSql.Tests/Transport/PostgreSqlTransportTests.cs
@@ -19,15 +19,15 @@ namespace Rebus.PostgreSql.Tests.Transport
 
 
         [TestFixture, Category(Categories.PostgreSql)]
-        public class SqlServerTransportBasicSendReceive : BasicSendReceive<PostgreSqlTransportFactory> { }
+        public class PostgreSqlTransportBasicSendReceive : BasicSendReceive<PostgreSqlTransportFactory> { }
 
         [TestFixture, Category(Categories.PostgreSql)]
-        public class SqlServerTransportMessageExpiration : MessageExpiration<PostgreSqlTransportFactory> { }
+        public class PostgreSqlTransportMessageExpiration : MessageExpiration<PostgreSqlTransportFactory> { }
 
 
         public ITransport CreateOneWayClient()
         {
-            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('-');
+            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
              _tablesToDrop.Add(tableName);
 
             var consoleLoggerFactory = new ConsoleLoggerFactory(false);

--- a/Rebus.PostgreSql.Tests/Transport/SqlTransportFactory.cs
+++ b/Rebus.PostgreSql.Tests/Transport/SqlTransportFactory.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rebus.Extensions;
+using Rebus.Logging;
+using Rebus.PostgreSql.Transport;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Transports;
+using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Transport;
+
+namespace Rebus.PostgreSql.Tests.Transport
+{
+    public class PostgreSqlTransportFactory : ITransportFactory
+    {
+
+         readonly HashSet<string> _tablesToDrop = new HashSet<string>();
+        readonly List<IDisposable> _disposables = new List<IDisposable>();
+
+
+        [TestFixture, Category(Categories.PostgreSql)]
+        public class SqlServerTransportBasicSendReceive : BasicSendReceive<PostgreSqlTransportFactory> { }
+
+        [TestFixture, Category(Categories.PostgreSql)]
+        public class SqlServerTransportMessageExpiration : MessageExpiration<PostgreSqlTransportFactory> { }
+
+
+        public ITransport CreateOneWayClient()
+        {
+            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('-');
+             _tablesToDrop.Add(tableName);
+
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var connectionHelper = new PostgresConnectionHelper(PostgreSqlTestHelper.ConnectionString);
+            var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
+            var transport = new PostgreSqlTransport(connectionHelper, tableName, null, consoleLoggerFactory, asyncTaskFactory);
+
+            _disposables.Add(transport);
+
+            transport.EnsureTableIsCreated();
+            transport.Initialize();
+
+            return transport;
+        }
+
+        public ITransport Create(string inputQueueAddress)
+        {
+            var tableName = ("rebus_messages_" + TestConfig.Suffix).TrimEnd('_');
+
+            _tablesToDrop.Add(tableName);
+
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var connectionHelper = new PostgresConnectionHelper(PostgreSqlTestHelper.ConnectionString);
+            var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
+            var transport = new PostgreSqlTransport(connectionHelper, tableName, inputQueueAddress, consoleLoggerFactory, asyncTaskFactory);
+
+            _disposables.Add(transport);
+
+            transport.EnsureTableIsCreated();
+            transport.Initialize();
+
+            return transport;
+        }
+
+        public void CleanUp()
+        {
+            _disposables.ForEach(d => d.Dispose());
+            _disposables.Clear();
+
+            _tablesToDrop.ForEach(PostgreSqlTestHelper.DropTable);
+            _tablesToDrop.Clear();
+        }
+    }
+}

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransport.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransport.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Extensions;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.PostgreSql.Transport;
+using Rebus.Tests.Contracts;
+using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Transport;
+using Timer = System.Timers.Timer;
+
+namespace Rebus.PostgreSql.Tests.Transport
+{
+    [TestFixture, Category(Categories.PostgreSql)]
+    public class TestPostgreSqlTransport : FixtureBase
+    {
+        private readonly string _tableName = "messages" + TestConfig.Suffix;
+        private PostgreSqlTransport _transport;
+        private CancellationToken _cancellationToken;
+        private const string QueueName = "input";
+
+        protected override void SetUp()
+        {
+            PostgreSqlTestHelper.DropTable(_tableName);
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
+            var connectionHelper = new PostgresConnectionHelper(PostgreSqlTestHelper.ConnectionString);
+            _transport = new PostgreSqlTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory,asyncTaskFactory );
+            _transport.EnsureTableIsCreated();
+
+            Using(_transport);
+
+            _transport.Initialize();
+            _cancellationToken = new CancellationTokenSource().Token;
+
+        }
+
+        [Test]
+        public async Task ReceivesSentMessageWhenTransactionIsCommitted()
+        {
+            using (var context = new DefaultTransactionContext())
+            {
+                await _transport.Send(QueueName, RecognizableMessage(), context);
+
+                await context.Complete();
+            }
+
+            using (var context = new DefaultTransactionContext())
+            {
+                var transportMessage = await _transport.Receive(context, _cancellationToken);
+
+                await context.Complete();
+
+                AssertMessageIsRecognized(transportMessage);
+            }
+        }
+
+       [Test]
+        public async Task DoesNotReceiveSentMessageWhenTransactionIsNotCommitted()
+        {
+            using (var context = new DefaultTransactionContext())
+            {
+                await _transport.Send(QueueName, RecognizableMessage(), context);
+
+                //await context.Complete();
+            }
+
+            using (var context = new DefaultTransactionContext())
+            {
+                var transportMessage = await _transport.Receive(context, _cancellationToken);
+
+                Assert.That(transportMessage, Is.Null);
+            }
+        }
+
+
+        [TestCase(1000)]
+        public async Task LotsOfAsyncStuffGoingDown(int numberOfMessages)
+        {
+            var receivedMessages = 0;
+            var messageIds = new ConcurrentDictionary<int, int>();
+
+            Console.WriteLine("Sending {0} messages", numberOfMessages);
+
+            await Task.WhenAll(Enumerable.Range(0, numberOfMessages)
+                .Select(async i =>
+                {
+                    using (var context = new DefaultTransactionContext())
+                    {
+                        await _transport.Send(QueueName, RecognizableMessage(i), context);
+                        await context.Complete();
+
+                        messageIds[i] = 0;
+                    }
+                }));
+
+            Console.WriteLine("Receiving {0} messages", numberOfMessages);
+
+            using (var timer = new Timer(1000))
+            {
+                timer.Elapsed += delegate
+                {
+                    Console.WriteLine("Received: {0} msgs", receivedMessages);
+                };
+                timer.Start();
+
+                await Task.WhenAll(Enumerable.Range(0, numberOfMessages)
+                    .Select(async i =>
+                    {
+                        using (var context = new DefaultTransactionContext())
+                        {
+                            var msg = await _transport.Receive(context, _cancellationToken);
+                            await context.Complete();
+
+                            Interlocked.Increment(ref receivedMessages);
+
+                            var id = int.Parse(msg.Headers["id"]);
+
+                            messageIds.AddOrUpdate(id, 1, (_, existing) => existing + 1);
+                        }
+                    }));
+
+                await Task.Delay(1000);
+            }
+
+            Assert.That(messageIds.Keys.OrderBy(k => k).ToArray(), Is.EqualTo(Enumerable.Range(0, numberOfMessages).ToArray()));
+
+            var kvpsDifferentThanOne = messageIds.Where(kvp => kvp.Value != 1).ToList();
+
+            if (kvpsDifferentThanOne.Any())
+            {
+                Assert.Fail(@"Oh no! the following IDs were not received exactly once:
+{0}",
+    string.Join(Environment.NewLine, kvpsDifferentThanOne.Select(kvp => $"   {kvp.Key}: {kvp.Value}")));
+            }
+        }
+
+
+
+         void AssertMessageIsRecognized(TransportMessage transportMessage)
+        {
+            Assert.That(transportMessage.Headers.GetValue("recognizzle"), Is.EqualTo("hej"));
+        }
+
+
+        static TransportMessage RecognizableMessage(int id = 0)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {"recognizzle", "hej"},
+                {"id", id.ToString()}
+            };
+            return new TransportMessage(headers, new byte[] { 1, 2, 3 });
+        }
+    }
+}

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportCleanup.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportCleanup.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.PostgreSql.Transport;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Extensions;
+using Rebus.Tests.Contracts.Utilities;
+
+namespace Rebus.PostgreSql.Tests.Transport
+{
+    public class TestPostgreSqlTransportCleanup
+    {
+        [TestFixture]
+        public class TestSqlServerTransportCleanup : FixtureBase
+        {
+            BuiltinHandlerActivator _activator;
+            ListLoggerFactory _loggerFactory;
+
+            protected override void SetUp()
+            {
+                var queueName = TestConfig.GetName("connection_timeout");
+
+                _activator = new BuiltinHandlerActivator();
+
+                Using(_activator);
+
+                _loggerFactory = new ListLoggerFactory(outputToConsole: true);
+
+                Configure.With(_activator)
+                    .Logging(l => l.Use(_loggerFactory))
+                    .Transport(t => t.UsePostgreSql(PostgreSqlTestHelper.ConnectionString, "Messages", queueName))
+                    .Start();
+            }
+
+            [Test]
+            public void DoesNotBarfInTheBackground()
+            {
+                var doneHandlingMessage = new ManualResetEvent(false);
+
+                _activator.Handle<string>(async str =>
+                {
+                    for (var count = 0; count < 5; count++)
+                    {
+                        Console.WriteLine("waiting...");
+                        await Task.Delay(TimeSpan.FromSeconds(20));
+                    }
+
+                    Console.WriteLine("done waiting!");
+
+                    doneHandlingMessage.Set();
+                });
+
+                _activator.Bus.SendLocal("hej med dig min ven!").Wait();
+
+                doneHandlingMessage.WaitOrDie(TimeSpan.FromMinutes(2));
+
+                var logLinesAboveInformation = _loggerFactory
+                    .Where(l => l.Level >= LogLevel.Warn)
+                    .ToList();
+
+                Assert.That(!logLinesAboveInformation.Any(), "Expected no warnings - got this: {0}", string.Join(Environment.NewLine, logLinesAboveInformation));
+            }
+        }
+    }
+}

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
@@ -38,9 +38,7 @@ namespace Rebus.PostgreSql.Tests.Transport
                     .Start();
             }
 
-            [TestCase(100)]
-            //[TestCase(1000)]
-            //[TestCase(1000)]
+            [TestCase(1000)]
             [TestCase(10000, Ignore = "run manually")]
             [TestCase(10000, Ignore = "run manually")]
             [TestCase(10000, Ignore = "run manually")]

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Net.Configuration;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Rebus.Activation;
@@ -8,6 +9,7 @@ using Rebus.Config;
 using Rebus.Tests.Contracts;
 using Rebus.Tests.Contracts.Utilities;
 using Rebus.Logging;
+using Rebus.Pipeline;
 using Rebus.PostgreSql.Transport;
 
 
@@ -15,57 +17,57 @@ using Rebus.PostgreSql.Transport;
 
 namespace Rebus.PostgreSql.Tests.Transport
 {
-        [TestFixture, Category(Categories.PostgreSql)]
-        public class TestPostgreSqlTransportReceivePerformance : FixtureBase
+    [TestFixture, Category(Categories.PostgreSql)]
+    public class TestPostgreSqlTransportReceivePerformance : FixtureBase
+    {
+        BuiltinHandlerActivator _adapter;
+
+        const string QueueName = "perftest";
+
+        static readonly string TableName = TestConfig.GetName("Messages");
+
+        protected override void SetUp()
         {
-            BuiltinHandlerActivator _adapter;
+            PostgreSqlTestHelper.DropTable(TableName);
 
-            const string QueueName = "perftest";
+            _adapter = Using(new BuiltinHandlerActivator());
 
-            static readonly string TableName = TestConfig.GetName("Messages");
-
-            protected override void SetUp()
-            {
-                PostgreSqlTestHelper.DropTable(TableName);
-
-                _adapter = Using(new BuiltinHandlerActivator());
-
-                Configure.With(_adapter)
-                    .Logging(l => l.ColoredConsole(LogLevel.Warn))
-                    .Transport(t => t.UsePostgreSql(PostgreSqlTestHelper.ConnectionString, TableName, QueueName))
-                    .Options(o =>
-                    {
-                        o.SetNumberOfWorkers(0);
-                        o.SetMaxParallelism(Environment.ProcessorCount);
-                    })
-                    .Start();
-            }
-
-            [TestCase(1000)]
-            [TestCase(10000, Ignore="enable manually")] 
-            public async Task NizzleName(int messageCount)
-            {
-
-                Console.WriteLine($"Sending {messageCount} messages...");
-
-                await Task.WhenAll(Enumerable.Range(0, messageCount)
-                    .Select(i => _adapter.Bus.SendLocal($"THIS IS MESSAGE {i}")));
-
-                var counter = new SharedCounter(messageCount);
-
-                _adapter.Handle<string>(async message => counter.Decrement());
-
-                Console.WriteLine("Waiting for messages to be received...");
-
-                var stopwtach = Stopwatch.StartNew();
-
-                _adapter.Bus.Advanced.Workers.SetNumberOfWorkers(3);
-
-                counter.WaitForResetEvent(messageCount / 500 + 5);
-
-                var elapsedSeconds = stopwtach.Elapsed.TotalSeconds;
-
-                Console.WriteLine($"{messageCount} messages received in {elapsedSeconds:0.0} s - that's {messageCount / elapsedSeconds:0.0} msg/s");
-            }
+            Configure.With(_adapter)
+                .Logging(l => l.ColoredConsole(LogLevel.Warn))
+                .Transport(t => t.UsePostgreSql(PostgreSqlTestHelper.ConnectionString, TableName, QueueName))
+                .Options(o =>
+                {
+                    o.SetNumberOfWorkers(0);
+                    o.SetMaxParallelism(20);
+                })
+                .Start();
         }
+
+        [TestCase(500)]
+        public async Task NizzleName(int messageCount)
+        {
+
+            Console.WriteLine($"Sending {messageCount} messages...");
+
+            await Task.WhenAll(Enumerable.Range(0, messageCount)
+                .Select(i => _adapter.Bus.SendLocal($"THIS IS MESSAGE {i}")));
+
+            var counter = new SharedCounter(messageCount);
+
+            _adapter.Handle<string>(async message => counter.Decrement());
+
+            Console.WriteLine("Waiting for messages to be received...");
+
+            var stopwtach = Stopwatch.StartNew();
+
+            _adapter.Bus.Advanced.Workers.SetNumberOfWorkers(3);
+
+            counter.WaitForResetEvent(messageCount / 500 + 20);
+
+            var elapsedSeconds = stopwtach.Elapsed.TotalSeconds;
+
+            Console.WriteLine(
+                $"{messageCount} messages received in {elapsedSeconds:0.0} s - that's {messageCount/elapsedSeconds:0.0} msg/s");
+        }
+    }
 }

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
@@ -10,6 +10,9 @@ using Rebus.Tests.Contracts.Utilities;
 using Rebus.Logging;
 using Rebus.PostgreSql.Transport;
 
+
+#pragma warning disable 1998
+
 namespace Rebus.PostgreSql.Tests.Transport
 {
         [TestFixture, Category(Categories.PostgreSql)]
@@ -39,9 +42,7 @@ namespace Rebus.PostgreSql.Tests.Transport
             }
 
             [TestCase(1000)]
-            [TestCase(10000, Ignore = "run manually")]
-            [TestCase(10000, Ignore = "run manually")]
-            [TestCase(10000, Ignore = "run manually")]
+            [TestCase(10000, Ignore="enable manually")] 
             public async Task NizzleName(int messageCount)
             {
 

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
@@ -43,7 +43,7 @@ namespace Rebus.PostgreSql.Tests.Transport
                 .Start();
         }
 
-        [TestCase(500)]
+        [TestCase(1000)]
         public async Task NizzleName(int messageCount)
         {
 
@@ -62,7 +62,7 @@ namespace Rebus.PostgreSql.Tests.Transport
 
             _adapter.Bus.Advanced.Workers.SetNumberOfWorkers(3);
 
-            counter.WaitForResetEvent(messageCount / 500 + 20);
+            counter.WaitForResetEvent(messageCount / 500 + 7);
 
             var elapsedSeconds = stopwtach.Elapsed.TotalSeconds;
 

--- a/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
+++ b/Rebus.PostgreSql.Tests/Transport/TestPostgreSqlTransportReceivePerformance.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rebus.Activation;
+using Rebus.Config;
+using Rebus.Tests.Contracts;
+using Rebus.Tests.Contracts.Utilities;
+using Rebus.Logging;
+using Rebus.PostgreSql.Transport;
+
+namespace Rebus.PostgreSql.Tests.Transport
+{
+        [TestFixture, Category(Categories.PostgreSql)]
+        public class TestPostgreSqlTransportReceivePerformance : FixtureBase
+        {
+            BuiltinHandlerActivator _adapter;
+
+            const string QueueName = "perftest";
+
+            static readonly string TableName = TestConfig.GetName("Messages");
+
+            protected override void SetUp()
+            {
+                PostgreSqlTestHelper.DropTable(TableName);
+
+                _adapter = Using(new BuiltinHandlerActivator());
+
+                Configure.With(_adapter)
+                    .Logging(l => l.ColoredConsole(LogLevel.Warn))
+                    .Transport(t => t.UsePostgreSql(PostgreSqlTestHelper.ConnectionString, TableName, QueueName))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(0);
+                        o.SetMaxParallelism(Environment.ProcessorCount);
+                    })
+                    .Start();
+            }
+
+            [TestCase(100)]
+            //[TestCase(1000)]
+            //[TestCase(1000)]
+            [TestCase(10000, Ignore = "run manually")]
+            [TestCase(10000, Ignore = "run manually")]
+            [TestCase(10000, Ignore = "run manually")]
+            public async Task NizzleName(int messageCount)
+            {
+
+                Console.WriteLine($"Sending {messageCount} messages...");
+
+                await Task.WhenAll(Enumerable.Range(0, messageCount)
+                    .Select(i => _adapter.Bus.SendLocal($"THIS IS MESSAGE {i}")));
+
+                var counter = new SharedCounter(messageCount);
+
+                _adapter.Handle<string>(async message => counter.Decrement());
+
+                Console.WriteLine("Waiting for messages to be received...");
+
+                var stopwtach = Stopwatch.StartNew();
+
+                _adapter.Bus.Advanced.Workers.SetNumberOfWorkers(3);
+
+                counter.WaitForResetEvent(messageCount / 500 + 5);
+
+                var elapsedSeconds = stopwtach.Elapsed.TotalSeconds;
+
+                Console.WriteLine($"{messageCount} messages received in {elapsedSeconds:0.0} s - that's {messageCount / elapsedSeconds:0.0} msg/s");
+            }
+        }
+}

--- a/Rebus.PostgreSql.Tests/packages.config
+++ b/Rebus.PostgreSql.Tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FluentAssertions" version="4.13.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Npgsql" version="3.1.7" targetFramework="net45" />
+  <package id="Npgsql" version="3.1.8" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="Rebus" version="2.0.1" targetFramework="net45" />
   <package id="Rebus.Tests.Contracts" version="2.0.1" targetFramework="net45" />

--- a/Rebus.PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgresConnection.cs
@@ -40,7 +40,7 @@ namespace Rebus.PostgreSql
         /// Completes the transaction
         /// </summary>
 
-        public async Task Complete()
+        public void Complete()
         {
             if (_currentTransaction != null)
             {

--- a/Rebus.PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgresConnection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Threading.Tasks;
 using Npgsql;
 
@@ -40,7 +41,7 @@ namespace Rebus.PostgreSql
         /// Completes the transaction
         /// </summary>
 
-        public void Complete()
+        public async Task Complete()
         {
             if (_currentTransaction == null) return;
             using (_currentTransaction)

--- a/Rebus.PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgresConnection.cs
@@ -42,41 +42,36 @@ namespace Rebus.PostgreSql
 
         public void Complete()
         {
-            if (_currentTransaction != null)
+            if (_currentTransaction == null) return;
+            using (_currentTransaction)
             {
-                using (_currentTransaction)
-                {
-                    _currentTransaction.Commit();
-                    _currentTransaction = null;
-                }
+                _currentTransaction.Commit();
+                _currentTransaction = null;
             }
         }
-        
-        
+
+
 
         /// <summary>
         /// Rolls back the transaction if it hasn't been completed
         /// </summary>
         public void Dispose()
         {
-            if (_currentTransaction != null) return;
             if (_disposed) return;
 
             try
             {
                 try
                 {
-                    if (_currentTransaction != null)
+                    if (_currentTransaction == null) return;
+                    using (_currentTransaction)
                     {
-                        using (_currentTransaction)
+                        try
                         {
-                            try
-                            {
-                                _currentTransaction.Rollback();
-                            }
-                            catch { }
-                            _currentTransaction = null;
+                            _currentTransaction.Rollback();
                         }
+                        catch { }
+                        _currentTransaction = null;
                     }
                 }
                 finally

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -60,7 +60,6 @@
     <Compile Include="Subscriptions\PostgreSqlSubscriptionStorage.cs" />
     <Compile Include="Timeouts\PostgreSqlTimeoutManager.cs" />
     <Compile Include="Properties\AssemblyInfo_Patch.cs" />
-    <Compile Include="Transport\DbConnectionProvider.cs" />
     <Compile Include="Transport\PostgresqlTransport.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -60,7 +60,9 @@
     <Compile Include="Subscriptions\PostgreSqlSubscriptionStorage.cs" />
     <Compile Include="Timeouts\PostgreSqlTimeoutManager.cs" />
     <Compile Include="Properties\AssemblyInfo_Patch.cs" />
+    <Compile Include="Transport\DisabledTimeoutManager.cs" />
     <Compile Include="Transport\PostgresqlTransport.cs" />
+    <Compile Include="Transport\PostgreSqlTransportConfigurationExtensions.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -33,8 +33,8 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Npgsql, Version=3.1.7.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Npgsql.3.1.7\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.1.8.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Npgsql.3.1.8\lib\net45\Npgsql.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Rebus, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -60,6 +60,8 @@
     <Compile Include="Subscriptions\PostgreSqlSubscriptionStorage.cs" />
     <Compile Include="Timeouts\PostgreSqlTimeoutManager.cs" />
     <Compile Include="Properties\AssemblyInfo_Patch.cs" />
+    <Compile Include="Transport\DbConnectionProvider.cs" />
+    <Compile Include="Transport\PostgresqlTransport.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rebus.PostgreSql/Transport/DisabledTimeoutManager.cs
+++ b/Rebus.PostgreSql/Transport/DisabledTimeoutManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Rebus.Extensions;
+using Rebus.Messages;
+using Rebus.Timeouts;
+
+namespace Rebus.PostgreSql.Transport
+{
+    class DisabledTimeoutManager : ITimeoutManager
+    {
+        public async Task Defer(DateTimeOffset approximateDueTime, Dictionary<string, string> headers, byte[] body)
+        {
+            var messageIdToPrint = headers.GetValueOrNull(Headers.MessageId) ?? "<no message ID>";
+
+            var message =
+                $"Received message with ID {messageIdToPrint} which is supposed to be deferred until {approximateDueTime} -" +
+                " this is a problem, because the internal handling of deferred messages is" +
+                " disabled when using SQL Server as the transport layer in, which" +
+                " case the native support for a specific visibility time is used...";
+
+            throw new InvalidOperationException(message);
+        }
+
+        public async Task<DueMessagesResult> GetDueMessages()
+        {
+            return DueMessagesResult.Empty;
+        }
+    }
+}

--- a/Rebus.PostgreSql/Transport/PostgreSqlTransportConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Transport/PostgreSqlTransportConfigurationExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Pipeline;
+using Rebus.Pipeline.Receive;
+using Rebus.Threading;
+using Rebus.Timeouts;
+using Rebus.Transport;
+
+namespace Rebus.PostgreSql.Transport
+{
+        /// <summary>
+        /// Configuration extensions for the SQL transport
+        /// </summary>
+        public static class PostgreSqlTransportConfigurationExtensions
+        {
+            /// <summary>
+            /// Configures Rebus to use PostgreSql as its transport. The table specified by <paramref name="tableName"/> will be used to
+            /// store messages, and the "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
+            /// The message table will automatically be created if it does not exist.
+            /// </summary>
+            public static void UsePostgreSql(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName)
+            {
+                Configure(configurer, loggerFactory => new PostgresConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+            }
+
+            static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, PostgresConnectionHelper> connectionProviderFactory, string tableName, string inputQueueName)
+            {
+                configurer.Register(context =>
+                {
+                    var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
+                    var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
+                    var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
+                    var transport = new PostgreSqlTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
+                    transport.EnsureTableIsCreated();
+                    return transport;
+                });
+
+                configurer.OtherService<ITimeoutManager>().Register(c => new DisabledTimeoutManager());
+
+                configurer.OtherService<IPipeline>().Decorate(c =>
+                {
+                    var pipeline = c.Get<IPipeline>();
+
+                    return new PipelineStepRemover(pipeline)
+                        .RemoveIncomingStep(s => s.GetType() == typeof(HandleDeferredMessagesStep));
+                });
+            }
+        }
+}

--- a/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
@@ -281,7 +281,7 @@ CREATE INDEX idx_expiration_{_tableName} ON {_tableName}
 );
 ");
 
-                connection.Complete().Wait();
+                connection.Complete();
             }
 
         }
@@ -320,7 +320,7 @@ CREATE INDEX idx_expiration_{_tableName} ON {_tableName}
                     async () =>
                     {
                         var dbConnection = await _connectionHelper.GetConnection();
-                        context.OnCommitted(async () => await dbConnection.Complete());
+                        context.OnCommitted(async () => dbConnection.Complete());
                         context.OnDisposed(() =>
                         {
                             dbConnection.Dispose();

--- a/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
@@ -316,7 +316,7 @@ CREATE INDEX idx_receive_{_tableName} ON {_tableName}
                     async () =>
                     {
                         var dbConnection = await _connectionHelper.GetConnection();
-                        context.OnCommitted(async () => dbConnection.Complete());
+                        context.OnCommitted(async () => await dbConnection.Complete());
                         context.OnDisposed(() =>
                         {
                             dbConnection.Dispose();

--- a/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
@@ -1,0 +1,391 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NpgsqlTypes;
+using Rebus.Bus;
+using Rebus.Exceptions;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.Threading;
+using Rebus.Transport;
+using System.Linq;
+using Npgsql;
+using Rebus.Extensions;
+using Rebus.Serialization;
+using Rebus.Time;
+
+namespace Rebus.PostgreSql.Transport
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class PostgreSqlTransport : ITransport, IInitializable, IDisposable
+    {
+        private readonly PostgresConnectionHelper _connectionHelper;
+        private readonly string _tableName;
+        private readonly string _inputQueueName;
+        private readonly IAsyncTaskFactory _asyncTaskFactory;
+        bool _disposed;
+        private ILog _log;
+
+         const string CurrentConnectionKey = "postgresql-transport-current-connection";
+        public const string MessagePriorityHeaderKey = "rbs2-msg-priority";
+        static readonly HeaderSerializer HeaderSerializer = new HeaderSerializer();
+        /// <summary>
+        /// 
+        /// </summary>
+        public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
+
+         readonly AsyncBottleneck _bottleneck = new AsyncBottleneck(20);
+
+          const int OperationCancelledNumber = 3980;
+
+        private readonly IAsyncTask _expiredMessagesCleanupTask;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionHelper"></param>
+        /// <param name="tableName"></param>
+        /// <param name="inputQueueName"></param>
+        /// <param name="rebusLoggerFactory"></param>
+        /// <param name="asyncTaskFactory"></param>
+        public PostgreSqlTransport(PostgresConnectionHelper connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory)
+        {
+            _connectionHelper = connectionHelper;
+            _tableName = tableName;
+            _inputQueueName = inputQueueName;
+            _asyncTaskFactory = asyncTaskFactory;
+            ExpiredMessagesCleanupInterval = DefaultExpiredMessagesCleanupInterval;
+            _expiredMessagesCleanupTask = asyncTaskFactory.Create("ExpiredMessagesCleanup",
+                PerformExpiredMessagesCleanupCycle, intervalSeconds: 60);
+
+            _log = rebusLoggerFactory.GetCurrentClassLogger();
+        }
+
+        public void Initialize()
+        {
+            if (_inputQueueName == null) return;
+            _expiredMessagesCleanupTask.Start();
+        }
+
+         /// <summary>
+         /// 
+         /// </summary>
+         public TimeSpan ExpiredMessagesCleanupInterval { get; set; }
+
+        public void CreateQueue(string address)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public async Task Send(string destinationAddress, TransportMessage message, ITransactionContext context)
+        {
+            var connection = await GetConnection(context);
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = $@"
+INSERT INTO {_tableName}
+(
+    recipient,
+    headers,
+    body,
+    priority,
+    visible,
+    expiration
+)
+VALUES
+(
+    @recipient,
+    @headers,
+    @body,
+    @priority,
+    now() + @ttlseconds,
+    now() + @visible
+)";
+
+                var headers = message.Headers.Clone();
+
+                var priority = GetMessagePriority(headers);
+                var initialVisibilityDelay = GetInitialVisibilityDelay(headers);
+                var ttlSeconds = GetTtlSeconds(headers);
+
+                // must be last because the other functions on the headers might change them
+                var serializedHeaders = HeaderSerializer.Serialize(headers);
+
+                command.Parameters.Add("recipient", NpgsqlDbType.Text ).Value = destinationAddress;
+                command.Parameters.Add("headers", NpgsqlDbType.Bytea).Value = serializedHeaders;
+                command.Parameters.Add("body", NpgsqlDbType.Bytea).Value = message.Body;
+                command.Parameters.Add("priority", NpgsqlDbType.Integer).Value = priority;
+                command.Parameters.Add("ttlseconds", NpgsqlDbType.Interval).Value = $"{ttlSeconds} s";
+                command.Parameters.Add("visible", NpgsqlDbType.Interval).Value = $"{initialVisibilityDelay} s";
+
+                
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+
+        public async Task<TransportMessage> Receive(ITransactionContext context, CancellationToken cancellationToken)
+        {
+            using (await _bottleneck.Enter(cancellationToken))
+            {
+                var connection = await GetConnection(context);
+
+                TransportMessage receivedTransportMessage;
+
+                using (var selectCommand = connection.CreateCommand())
+                {
+                    selectCommand.CommandText = $@"
+DELETE from {_tableName} 
+where id = 
+(
+    select id from {_tableName}
+    where recipient = @recipient
+    and visible < now()
+    and expiration > now()
+    order by priority asc, id asc
+    for update skip locked
+    limit 1
+)
+returning id,
+headers,
+body
+";
+
+                    selectCommand.Parameters.Add("recipient", NpgsqlDbType.Text).Value = _inputQueueName;
+
+                    try
+                    {
+                        using (var reader = await selectCommand.ExecuteReaderAsync(cancellationToken))
+                        {
+                            if (!await reader.ReadAsync(cancellationToken)) return null;
+
+                            var headers = reader["headers"];
+                            var headersDictionary = HeaderSerializer.Deserialize((byte[])headers);
+                            var body = (byte[])reader["body"];
+
+                            receivedTransportMessage = new TransportMessage(headersDictionary, body);
+                        }
+                    }
+                    catch (SqlException sqlException) when (sqlException.Number == OperationCancelledNumber)
+                    {
+                        // ADO.NET does not throw the right exception when the task gets cancelled - therefore we need to do this:
+                        throw new TaskCanceledException("Receive operation was cancelled", sqlException);
+                    }
+                }
+
+                return receivedTransportMessage;
+            }
+        }
+
+        async Task PerformExpiredMessagesCleanupCycle()
+        {
+            var results = 0;
+            var stopwatch = Stopwatch.StartNew();
+
+            while (true)
+            {
+                using (var connection = await _connectionHelper.GetConnection())
+                {
+                    int affectedRows;
+
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText =
+                            $@"
+	            Delete FROM {_tableName} 
+				WHERE recipient = @recipient 
+				AND [expiration] < getdate()
+";
+                        command.Parameters.Add("recipient",  (NpgsqlDbType) DbType.String).Value = _inputQueueName;
+                        affectedRows = await command.ExecuteNonQueryAsync();
+                    }
+
+                    results += affectedRows;
+                    connection.Complete();
+
+                    if (affectedRows == 0) break;
+                }
+            }
+
+            if (results > 0)
+            {
+                _log.Info(
+                    "Performed expired messages cleanup in {0} - {1} expired messages with recipient {2} were deleted",
+                    stopwatch.Elapsed, results, _inputQueueName);
+            }
+        }
+
+        public string Address { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        public void EnsureTableIsCreated()
+        {
+            try
+            {
+                CreateSchema();
+            }
+            catch (SqlException exception)
+            {
+                throw new RebusApplicationException(exception, $"Error attempting to initialize SQL transport schema with mesages table [dbo].[{_tableName}]");
+            }
+        }
+
+        private void CreateSchema()
+        {
+            using (var connection = _connectionHelper.GetConnection().Result)
+            {
+                var tableNames = connection.GetTableNames();
+
+                if (tableNames.Contains(_tableName, StringComparer.OrdinalIgnoreCase))
+                {
+                    _log.Info("Database already contains a table named '{0}' - will not create anything", _tableName);
+                    return;
+                }
+
+                _log.Info("Table '{0}' does not exist - it will be created now", _tableName);
+
+                ExecuteCommands(connection, $@"
+CREATE TABLE {_tableName}
+(
+	id serial NOT NULL,
+	recipient text NOT NULL,
+	priority int NOT NULL,
+    expiration timestamp NOT NULL,
+    visible timestamp NOT NULL,
+	headers bytea NOT NULL,
+	body bytea NOT NULL,
+    PRIMARY KEY (recipient, priority, id)
+);
+----
+CREATE INDEX idx_receive_{_tableName} ON {_tableName}
+(
+	recipient ASC,
+	priority ASC,
+    visible ASC,
+    expiration ASC,
+	id ASC
+);
+----
+CREATE INDEX idx_expiration_{_tableName} ON {_tableName}
+(
+    expiration ASC
+);
+");
+
+                connection.Complete().Wait();
+            }
+
+        }
+
+        static void ExecuteCommands(PostgresConnection connection, string sqlCommands)
+        {
+            foreach (var sqlCommand in sqlCommands.Split(new[] { "----" }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = sqlCommand;
+
+                    Execute(command);
+                }
+            }
+        }
+
+        static void Execute(IDbCommand command)
+        {
+            try
+            {
+                command.ExecuteNonQuery();
+            }
+            catch (NpgsqlException exception)
+            {
+                throw new RebusApplicationException(exception, $@"Error executing SQL command
+{command.CommandText}
+");
+            }
+        }
+
+        Task<PostgresConnection> GetConnection(ITransactionContext context)
+        {
+            return context
+                .GetOrAdd(CurrentConnectionKey,
+                    async () =>
+                    {
+                        var dbConnection = await _connectionHelper.GetConnection();
+                        context.OnCommitted(async () => await dbConnection.Complete());
+                        context.OnDisposed(() =>
+                        {
+                            dbConnection.Dispose();
+                        });
+                        return dbConnection;
+                    });
+        }
+
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+
+            try
+            {
+                _expiredMessagesCleanupTask.Dispose();
+            }
+            finally
+            {
+                _disposed = true;
+            }
+        }
+
+        static int GetMessagePriority(Dictionary<string, string> headers)
+        {
+            var valueOrNull = headers.GetValueOrNull(MessagePriorityHeaderKey);
+            if (valueOrNull == null) return 0;
+
+            try
+            {
+                return int.Parse(valueOrNull);
+            }
+            catch (Exception exception)
+            {
+                throw new FormatException($"Could not parse '{valueOrNull}' into an Int32!", exception);
+            }
+        }
+
+        static int GetInitialVisibilityDelay(IDictionary<string, string> headers)
+        {
+            string deferredUntilDateTimeOffsetString;
+
+            if (!headers.TryGetValue(Headers.DeferredUntil, out deferredUntilDateTimeOffsetString))
+            {
+                return 0;
+            }
+
+            var deferredUntilTime = deferredUntilDateTimeOffsetString.ToDateTimeOffset();
+
+            headers.Remove(Headers.DeferredUntil);
+
+            return (int)(deferredUntilTime - RebusTime.Now).TotalSeconds;
+        }
+
+        static int GetTtlSeconds(IReadOnlyDictionary<string, string> headers)
+        {
+            const int defaultTtlSecondsAbout60Years = int.MaxValue;
+
+            if (!headers.ContainsKey(Headers.TimeToBeReceived))
+                return defaultTtlSecondsAbout60Years;
+
+            var timeToBeReceivedStr = headers[Headers.TimeToBeReceived];
+            var timeToBeReceived = TimeSpan.Parse(timeToBeReceivedStr);
+
+            return (int)timeToBeReceived.TotalSeconds;
+        }
+    }
+}

--- a/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/Transport/PostgresqlTransport.cs
@@ -41,7 +41,7 @@ namespace Rebus.PostgreSql.Transport
         /// </summary>
         public static readonly TimeSpan DefaultExpiredMessagesCleanupInterval = TimeSpan.FromSeconds(20);
 
-         readonly AsyncBottleneck _bottleneck = new AsyncBottleneck(Environment.ProcessorCount);
+        readonly AsyncBottleneck _bottleneck = new AsyncBottleneck(20);
 
           const int OperationCancelledNumber = 3980;
 

--- a/Rebus.PostgreSql/packages.config
+++ b/Rebus.PostgreSql/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Npgsql" version="3.1.7" targetFramework="net45" />
+  <package id="Npgsql" version="3.1.8" targetFramework="net45" />
   <package id="Rebus" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is a crack at getting PostgreSql to handle the rebus transport.  As it stands though, I wouldn't be merging this, as I hit a wall when it comes to how PostgreSql / Rebus handles the db connections, so if anyone has some bright ideas, I'll all ears.

As it stands, in the TestPostgreSqlTransportReceivePerformance, if you specify in the test the number of messages above the postgresql `show max_connections` number, it will exhaust the connection pool (but it seems to vary as to when the pool is exhausted).  This is traditionally set to 100 in new installs, so I could just set to higher (I believe in the connection string) but I think this is hiding other issues.

Reading up on Npgsql, it _should_ return connections to the pool once they are closed, so I'm thinking it is something to do with my connection logic which I largely copied from the SqlServer implementation.

The queue pop is implemented using PG 9.5s skip locked syntax so this won't work < 9.5 but performance _should_ be up there with SqlServer if not better.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
