### PR TITLE
Added callback for additional connection setup, if necessary.

### DIFF
--- a/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using Rebus.Auditing.Sagas;
+﻿using System;
+using Npgsql;
 using Rebus.Logging;
 using Rebus.PostgreSql;
 using Rebus.PostgreSql.Sagas;
@@ -16,14 +18,15 @@ namespace Rebus.Config
     public static class PostgreSqlConfigurationExtensions
     {
         /// <summary>
-        /// Configures Rebus to use SQL Server to store saga data snapshots, using the specified table to store the data
+        /// Configures Rebus to use PostgreSQL to store saga data snapshots, using the specified table to store the data
         /// </summary>
         public static void StoreInPostgres(this StandardConfigurer<ISagaSnapshotStorage> configurer,
-            string connectionString, string tableName, bool automaticallyCreateTables = true)
+            string connectionString, string tableName, bool automaticallyCreateTables = true, 
+            Action<NpgsqlConnection> additionalConnectionSetup = null)
         {
             configurer.Register(c =>
             {
-                var sagaStorage = new PostgreSqlSagaSnapshotStorage(new PostgresConnectionHelper(connectionString), tableName);
+                var sagaStorage = new PostgreSqlSagaSnapshotStorage(new PostgresConnectionHelper(connectionString, additionalConnectionSetup), tableName);
 
                 if (automaticallyCreateTables)
                 {
@@ -35,16 +38,16 @@ namespace Rebus.Config
         }
 
         /// <summary>
-        /// Configures Rebus to use SQL Server to store sagas, using the tables specified to store data and indexed properties respectively.
+        /// Configures Rebus to use PostgreSQL to store sagas, using the tables specified to store data and indexed properties respectively.
         /// </summary>
         public static void StoreInPostgres(this StandardConfigurer<ISagaStorage> configurer,
             string connectionString, string dataTableName, string indexTableName,
-            bool automaticallyCreateTables = true)
+            bool automaticallyCreateTables = true, Action<NpgsqlConnection> additionalConnectionSetup = null)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var sagaStorage = new PostgreSqlSagaStorage(new PostgresConnectionHelper(connectionString), dataTableName, indexTableName, rebusLoggerFactory);
+                var sagaStorage = new PostgreSqlSagaStorage(new PostgresConnectionHelper(connectionString, additionalConnectionSetup), dataTableName, indexTableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -58,12 +61,13 @@ namespace Rebus.Config
         /// <summary>
         /// Configures Rebus to use PostgreSQL to store timeouts.
         /// </summary>
-        public static void StoreInPostgres(this StandardConfigurer<ITimeoutManager> configurer, string connectionString, string tableName, bool automaticallyCreateTables = true)
+        public static void StoreInPostgres(this StandardConfigurer<ITimeoutManager> configurer, string connectionString, string tableName, 
+            bool automaticallyCreateTables = true, Action<NpgsqlConnection> additionalConnectionSetup = null)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var subscriptionStorage = new PostgreSqlTimeoutManager(new PostgresConnectionHelper(connectionString), tableName, rebusLoggerFactory);
+                var subscriptionStorage = new PostgreSqlTimeoutManager(new PostgresConnectionHelper(connectionString, additionalConnectionSetup), tableName, rebusLoggerFactory);
 
                 if (automaticallyCreateTables)
                 {
@@ -80,12 +84,12 @@ namespace Rebus.Config
         /// default behavior.
         /// </summary>
         public static void StoreInPostgres(this StandardConfigurer<ISubscriptionStorage> configurer,
-            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true)
+            string connectionString, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, Action<NpgsqlConnection> additionalConnectionSetup = null)
         {
             configurer.Register(c =>
             {
                 var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-                var connectionHelper = new PostgresConnectionHelper(connectionString);
+                var connectionHelper = new PostgresConnectionHelper(connectionString, additionalConnectionSetup);
                 var subscriptionStorage = new PostgreSqlSubscriptionStorage(
                     connectionHelper, tableName, isCentralized, rebusLoggerFactory);
 

--- a/Rebus.PostgreSql/PostgreSql/PostgresConnectionHelper.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgresConnectionHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Threading.Tasks;
 using Npgsql;
 
@@ -10,6 +11,7 @@ namespace Rebus.PostgreSql
     public class PostgresConnectionHelper
     {
         readonly string _connectionString;
+        private readonly Action<NpgsqlConnection> _additionalConnectionSetupCallback;
 
         /// <summary>
         /// Constructs this thingie
@@ -20,12 +22,28 @@ namespace Rebus.PostgreSql
         }
 
         /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        /// <param name="connectionString">Connection string.</param>
+        /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
+        /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
+        public PostgresConnectionHelper(string connectionString, Action<NpgsqlConnection> additionalConnectionSetupCallback)
+        {
+            _connectionString = connectionString;
+            _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
+        }
+
+
+        /// <summary>
         /// Gets a fresh, open and ready-to-use connection wrapper
         /// </summary>
         public async Task<PostgresConnection> GetConnection()
         {
             var connection = new NpgsqlConnection(_connectionString);
             
+            if (_additionalConnectionSetupCallback != null)
+                _additionalConnectionSetupCallback.Invoke(connection);
+
             await connection.OpenAsync();
 
             var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);


### PR DESCRIPTION
This allows the user to configure the connection based on other requirements such as authenticating using client certificates.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
