### PR TITLE
Added callback for additional connection setup, if necessary.

### DIFF
--- a/Rebus.PostgreSql/PostgresConnectionHelper.cs
+++ b/Rebus.PostgreSql/PostgresConnectionHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Threading.Tasks;
 using Npgsql;
 
@@ -10,6 +11,7 @@ namespace Rebus.PostgreSql
     public class PostgresConnectionHelper
     {
         readonly string _connectionString;
+        private readonly Action<NpgsqlConnection> _additionalConnectionSetupCallback;
 
         /// <summary>
         /// Constructs this thingie
@@ -20,12 +22,28 @@ namespace Rebus.PostgreSql
         }
 
         /// <summary>
+        /// Constructs this thingie
+        /// </summary>
+        /// <param name="connectionString">Connection string.</param>
+        /// <param name="additionalConnectionSetupCallback">Additional setup to be performed prior to opening each connection. 
+        /// Useful for configuring client certificate authentication, as well as set up other callbacks.</param>
+        public PostgresConnectionHelper(string connectionString, Action<NpgsqlConnection> additionalConnectionSetupCallback)
+        {
+            _connectionString = connectionString;
+            _additionalConnectionSetupCallback = additionalConnectionSetupCallback;
+        }
+
+
+        /// <summary>
         /// Gets a fresh, open and ready-to-use connection wrapper
         /// </summary>
         public async Task<PostgresConnection> GetConnection()
         {
             var connection = new NpgsqlConnection(_connectionString);
             
+            if (_additionalConnectionSetupCallback != null)
+                _additionalConnectionSetupCallback.Invoke(connection);
+
             await connection.OpenAsync();
 
             var currentTransaction = connection.BeginTransaction(IsolationLevel.ReadCommitted);


### PR DESCRIPTION
This allows the user to configure the connection based on other requirements such as authenticating using client certificates.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
