### PR TITLE
Add Connection Provider Support To Postgres Transport

### DIFF
--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -7,13 +7,13 @@ namespace Rebus.PostgreSql.Tests
     public class PostgreSqlTestHelper
     {
         const string TableDoesNotExist = "42P01";
-        static readonly PostgresConnectionHelper PostgresConnectionHelper = new PostgresConnectionHelper(ConnectionString);
+        static readonly  IPostgresConnectionProvider PostgresConnectionHelper = new PostgresConnectionHelper(ConnectionString);
 
         public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
 
         public static string ConnectionString => GetConnectionStringForDatabase(DatabaseName);
 
-        public static PostgresConnectionHelper ConnectionHelper => PostgresConnectionHelper;
+        public static IPostgresConnectionProvider ConnectionHelper => PostgresConnectionHelper;
 
         public static void DropTable(string tableName)
         {

--- a/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
@@ -36,7 +36,7 @@ namespace Rebus.PostgreSql.Transport
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
 
-        static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, PostgresConnectionHelper> connectionProviderFactory, string tableName, string inputQueueName)
+        static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, IPostgresConnectionProvider> connectionProviderFactory, string tableName, string inputQueueName)
         {
             configurer.Register(context =>
             {

--- a/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
@@ -21,7 +21,17 @@ namespace Rebus.PostgreSql.Transport
         /// </summary>
         public static void UsePostgreSql(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionOrConnectionStringName, string tableName, string inputQueueName)
         {
-            Configure(configurer, loggerFactory => new PostgresConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+            UsePostgreSql(configurer,  new PostgresConnectionHelper(connectionStringOrConnectionOrConnectionStringName), tableName, inputQueueName);
+        }
+
+        /// <summary>
+        /// Configures Rebus to use PostgreSql as its transport. The table specified by <paramref name="tableName"/> will be used to
+        /// store messages, and the "queue" specified by <paramref name="inputQueueName"/> will be used when querying for messages.
+        /// The message table will automatically be created if it does not exist.
+        /// </summary>
+        public static void UsePostgreSql(this StandardConfigurer<ITransport> configurer, IPostgresConnectionProvider connectionProvider, string tableName, string inputQueueName)
+        {
+            Configure(configurer, connectionProvider, tableName, inputQueueName);
         }
 
         /// <summary>
@@ -31,18 +41,26 @@ namespace Rebus.PostgreSql.Transport
         /// </summary>
         public static void UsePostgreSqlAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionStringOrConnectionStringName, string tableName)
         {
-            Configure(configurer, loggerFactory => new PostgresConnectionHelper(connectionStringOrConnectionStringName), tableName, null);
+            UsePostgreSqlAsOneWayClient(configurer, new PostgresConnectionHelper(connectionStringOrConnectionStringName), tableName);
+        }
 
+        /// <summary>
+        /// Configures Rebus to use PostgreSql to transport messages as a one-way client (i.e. will not be able to receive any messages).
+        /// The table specified by <paramref name="tableName"/> will be used to store messages.
+        /// The message table will automatically be created if it does not exist.
+        /// </summary>
+        public static void UsePostgreSqlAsOneWayClient(this StandardConfigurer<ITransport> configurer, IPostgresConnectionProvider  connectionProvider, string tableName)
+        {
+            Configure(configurer, connectionProvider, tableName, null);
             OneWayClientBackdoor.ConfigureOneWayClient(configurer);
         }
 
-        static void Configure(StandardConfigurer<ITransport> configurer, Func<IRebusLoggerFactory, IPostgresConnectionProvider> connectionProviderFactory, string tableName, string inputQueueName)
+        static void Configure(StandardConfigurer<ITransport> configurer, IPostgresConnectionProvider connectionProvider, string tableName, string inputQueueName)
         {
             configurer.Register(context =>
             {
                 var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
                 var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
-                var connectionProvider = connectionProviderFactory(rebusLoggerFactory);
                 var transport = new PostgreSqlTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory);
                 transport.EnsureTableIsCreated();
                 return transport;

--- a/Rebus.PostgreSql/PostgreSql/CustomPostgresConnectionProvider.cs
+++ b/Rebus.PostgreSql/PostgreSql/CustomPostgresConnectionProvider.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace Rebus.PostgreSql
+{
+    /// <summary>
+    /// Implementation of <see cref="IPostgresConnectionProvider"/> that provides the connection using a user-provided function.
+    /// Will optionally start transactions whenever the connection is provided.
+    /// 
+    /// </summary>
+    public class CustomPostgresConnectionProvider : IPostgresConnectionProvider
+    {
+        readonly Func<Task<NpgsqlConnection>> _provideConnection;
+        readonly bool _autoStartTransactions;
+
+        /// <summary>
+        /// Constructor that allows specifying transaction behavior
+        /// Defaults to not starting transactions
+        /// </summary>
+        /// <param name="provideConnection">Function that will provide an asynchronous <see cref="NpgsqlConnection"/> when invoked</param>
+        /// <param name="autoStartTransactions">Whether to automatically start transaction every time a new connection is provided</param>
+        public CustomPostgresConnectionProvider(Func<Task<NpgsqlConnection>> provideConnection, bool autoStartTransactions = false)
+        {
+            _provideConnection = provideConnection;
+            _autoStartTransactions = autoStartTransactions;
+        }
+
+
+        
+        /// <summary>
+        /// Constructor that allows specifying transaction behavior
+        /// Defaults to not starting transactions
+        ///  Allows providing the connection through a non-async Func
+        /// </summary>
+        /// <param name="provideConnection">Function that will provide an <see cref="NpgsqlConnection"/> when invoked</param>
+        /// <param name="autoStartTransactions">Whether to automatically start transaction every time a new connection is provided</param>
+        public CustomPostgresConnectionProvider(Func<NpgsqlConnection> provideConnection, bool autoStartTransactions = false) : this(()=>Task.FromResult(provideConnection()), autoStartTransactions)
+        {
+        }
+
+
+
+        /// <summary>
+        /// Getst the connection by using user-provided Func. Will optionally start a transaction on the connection if configured to do so. 
+        /// 
+        /// </summary>
+        /// <returns>The <see cref="PostgresConnection"/> object wrapping the connection and transaction</returns>
+        public async Task<PostgresConnection> GetConnection()
+        {
+            var connection = await _provideConnection();
+            var transaction = _autoStartTransactions ? connection.BeginTransaction(IsolationLevel.ReadCommitted) : null;
+            return new PostgresConnection(connection, transaction);
+        }
+    }
+}

--- a/Rebus.PostgreSql/PostgreSql/IPostgresConnectionProvider.cs
+++ b/Rebus.PostgreSql/PostgreSql/IPostgresConnectionProvider.cs
@@ -1,6 +1,5 @@
 using System.Data.SqlClient;
 using System.Threading.Tasks;
-using Npgsql;
 
 namespace Rebus.PostgreSql
 {

--- a/Rebus.PostgreSql/PostgreSql/IPostgresConnectionProvider.cs
+++ b/Rebus.PostgreSql/PostgreSql/IPostgresConnectionProvider.cs
@@ -1,0 +1,18 @@
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace Rebus.PostgreSql
+{
+    /// <summary>
+    /// PostgreSql Server database connection provider that allows for easily changing how the current <see cref="PostgresConnection"/> is obtained,
+    /// possibly also changing how transactions are handled
+    /// </summary>
+    public interface IPostgresConnectionProvider
+    {
+        /// <summary>
+        /// Gets a wrapper with the current <see cref="PostgresConnection"/> inside
+        /// </summary>
+        Task<PostgresConnection> GetConnection();
+    }
+}

--- a/Rebus.PostgreSql/PostgreSql/PostgresConnectionHelper.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgresConnectionHelper.cs
@@ -8,7 +8,7 @@ namespace Rebus.PostgreSql
     /// <summary>
     /// Helps with managing <see cref="NpgsqlConnection"/>s
     /// </summary>
-    public class PostgresConnectionHelper
+    public class PostgresConnectionHelper : IPostgresConnectionProvider
     {
         readonly string _connectionString;
         private readonly Action<NpgsqlConnection> _additionalConnectionSetupCallback;

--- a/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaSnapshotStorage.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaSnapshotStorage.cs
@@ -16,13 +16,13 @@ namespace Rebus.PostgreSql.Sagas
     {
         readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
         readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
-        readonly PostgresConnectionHelper _connectionHelper;
+        readonly IPostgresConnectionProvider _connectionHelper;
         readonly string _tableName;
 
         /// <summary>
         /// Constructs the storage
         /// </summary>
-        public PostgreSqlSagaSnapshotStorage(PostgresConnectionHelper connectionHelper, string tableName)
+        public PostgreSqlSagaSnapshotStorage(IPostgresConnectionProvider connectionHelper, string tableName)
         {
             if (connectionHelper == null) throw new ArgumentNullException(nameof(connectionHelper));
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));

--- a/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaStorage.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaStorage.cs
@@ -23,7 +23,7 @@ namespace Rebus.PostgreSql.Sagas
         static readonly string IdPropertyName = Reflect.Path<ISagaData>(d => d.Id);
 
         readonly ObjectSerializer _objectSerializer = new ObjectSerializer();
-        readonly PostgresConnectionHelper _connectionHelper;
+        readonly IPostgresConnectionProvider _connectionHelper;
         readonly string _dataTableName;
         readonly string _indexTableName;
         readonly ILog _log;
@@ -31,7 +31,7 @@ namespace Rebus.PostgreSql.Sagas
         /// <summary>
         /// Constructs the saga storage
         /// </summary>
-        public PostgreSqlSagaStorage(PostgresConnectionHelper connectionHelper, string dataTableName, string indexTableName, IRebusLoggerFactory rebusLoggerFactory)
+        public PostgreSqlSagaStorage(IPostgresConnectionProvider connectionHelper, string dataTableName, string indexTableName, IRebusLoggerFactory rebusLoggerFactory)
         {
             if (connectionHelper == null) throw new ArgumentNullException(nameof(connectionHelper));
             if (dataTableName == null) throw new ArgumentNullException(nameof(dataTableName));

--- a/Rebus.PostgreSql/PostgreSql/Subscriptions/PostgreSqlSubscriptionStorage.cs
+++ b/Rebus.PostgreSql/PostgreSql/Subscriptions/PostgreSqlSubscriptionStorage.cs
@@ -16,7 +16,7 @@ namespace Rebus.PostgreSql.Subscriptions
     {
         const string UniqueKeyViolation = "23505";
 
-        readonly PostgresConnectionHelper _connectionHelper;
+        readonly IPostgresConnectionProvider _connectionHelper;
         readonly string _tableName;
         readonly ILog _log;
 
@@ -25,7 +25,7 @@ namespace Rebus.PostgreSql.Subscriptions
         /// If <paramref name="isCentralized"/> is true, subscribing/unsubscribing will be short-circuited by manipulating
         /// subscriptions directly, instead of requesting via messages
         /// </summary>
-        public PostgreSqlSubscriptionStorage(PostgresConnectionHelper connectionHelper, string tableName, bool isCentralized, IRebusLoggerFactory rebusLoggerFactory)
+        public PostgreSqlSubscriptionStorage(IPostgresConnectionProvider connectionHelper, string tableName, bool isCentralized, IRebusLoggerFactory rebusLoggerFactory)
         {
             if (connectionHelper == null) throw new ArgumentNullException(nameof(connectionHelper));
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));

--- a/Rebus.PostgreSql/PostgreSql/Timeouts/PostgreSqlTimeoutManager.cs
+++ b/Rebus.PostgreSql/PostgreSql/Timeouts/PostgreSqlTimeoutManager.cs
@@ -19,14 +19,14 @@ namespace Rebus.PostgreSql.Timeouts
     public class PostgreSqlTimeoutManager : ITimeoutManager
     {
         readonly DictionarySerializer _dictionarySerializer = new DictionarySerializer();
-        readonly PostgresConnectionHelper _connectionHelper;
+        readonly IPostgresConnectionProvider _connectionHelper;
         readonly string _tableName;
         readonly ILog _log;
 
         /// <summary>
         /// Constructs the timeout manager
         /// </summary>
-        public PostgreSqlTimeoutManager(PostgresConnectionHelper connectionHelper, string tableName, IRebusLoggerFactory rebusLoggerFactory)
+        public PostgreSqlTimeoutManager(IPostgresConnectionProvider connectionHelper, string tableName, IRebusLoggerFactory rebusLoggerFactory)
         {
             if (connectionHelper == null) throw new ArgumentNullException(nameof(connectionHelper));
             if (tableName == null) throw new ArgumentNullException(nameof(tableName));

--- a/Rebus.PostgreSql/PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/PostgreSql/Transport/PostgresqlTransport.cs
@@ -30,7 +30,7 @@ namespace Rebus.PostgreSql.Transport
 
         static readonly HeaderSerializer HeaderSerializer = new HeaderSerializer();
 
-        readonly PostgresConnectionHelper _connectionHelper;
+        readonly IPostgresConnectionProvider _connectionHelper;
         readonly string _tableName;
         readonly string _inputQueueName;
         readonly AsyncBottleneck _receiveBottleneck = new AsyncBottleneck(20);
@@ -59,7 +59,7 @@ namespace Rebus.PostgreSql.Transport
         /// <param name="inputQueueName"></param>
         /// <param name="rebusLoggerFactory"></param>
         /// <param name="asyncTaskFactory"></param>
-        public PostgreSqlTransport(PostgresConnectionHelper connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory)
+        public PostgreSqlTransport(IPostgresConnectionProvider connectionHelper, string tableName, string inputQueueName, IRebusLoggerFactory rebusLoggerFactory, IAsyncTaskFactory asyncTaskFactory)
         {
             if (rebusLoggerFactory == null) throw new ArgumentNullException(nameof(rebusLoggerFactory));
             if (asyncTaskFactory == null) throw new ArgumentNullException(nameof(asyncTaskFactory));


### PR DESCRIPTION
This creates a new interface `IPostgresConnectionProvider` that may be used to customize the way connections and transactions are handled by the underlying postgres transport and persistence code. Additional configuration extensions are provided that accept this new interface. Existing methods that take a connection string are still there  and simply automatically use the previous `PostgresConnectionHelper` (which now also implements `IPostgresConnectionProvider`) to retain backwards-compatible behavior.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
