### PR TITLE
Added support for ambient transactions

### DIFF
--- a/Rebus.PostgreSql.Tests/Bugs/PublishWithinTransactionScopeTests.cs
+++ b/Rebus.PostgreSql.Tests/Bugs/PublishWithinTransactionScopeTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+using NUnit.Framework;
+using Rebus.Extensions;
+using Rebus.Logging;
+using Rebus.Messages;
+using Rebus.PostgreSql.Transport;
+using Rebus.Tests.Contracts;
+using Rebus.Threading.TaskParallelLibrary;
+using Rebus.Transport;
+
+namespace Rebus.PostgreSql.Tests.Bugs
+{
+    [TestFixture, Category(Categories.PostgreSql)]
+    public class PublishWithinTransactionScopeTests : FixtureBase
+    {
+        readonly string _tableName = "messages" + TestConfig.Suffix;
+        PostgreSqlTransport _transport;
+        CancellationToken _cancellationToken;
+        const string QueueName = "input";
+
+        protected override void SetUp()
+        {
+            PostgreSqlTestHelper.DropTable(_tableName);
+            var consoleLoggerFactory = new ConsoleLoggerFactory(false);
+            var asyncTaskFactory = new TplAsyncTaskFactory(consoleLoggerFactory);
+            var connectionHelper = new PostgresConnectionHelper(PostgreSqlTestHelper.ConnectionString);
+            _transport = new PostgreSqlTransport(connectionHelper, _tableName, QueueName, consoleLoggerFactory, asyncTaskFactory);
+            _transport.EnsureTableIsCreated();
+
+            Using(_transport);
+
+            _transport.Initialize();
+            _cancellationToken = new CancellationTokenSource().Token;
+        }
+
+        [Test]
+        public async Task ReceivesSentMessageWhenTransactionIsCommittedFromWithinAmbientDotNetTransactionScope()
+        {
+            using (var txScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                using (var scope = new RebusTransactionScope())
+                {
+                    await _transport.Send(QueueName, RecognizableMessage(), scope.TransactionContext);
+
+                    await scope.CompleteAsync();
+                }
+                txScope.Complete();
+            }
+
+            using (var scope = new RebusTransactionScope())
+            {
+                var transportMessage = await _transport.Receive(scope.TransactionContext, _cancellationToken);
+
+                await scope.CompleteAsync();
+
+                AssertMessageIsRecognized(transportMessage);
+            }
+        }
+
+        void AssertMessageIsRecognized(TransportMessage transportMessage)
+        {
+            Assert.That(transportMessage.Headers.GetValue("recognizzle"), Is.EqualTo("hej"));
+        }
+
+        static TransportMessage RecognizableMessage(int id = 0)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                {"recognizzle", "hej"},
+                {"id", id.ToString()}
+            };
+            return new TransportMessage(headers, new byte[] { 1, 2, 3 });
+        }
+    }
+}

--- a/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
+++ b/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
@@ -35,4 +35,7 @@
     <PackageReference Include="rebus" Version="4.0.0" />
     <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
 </Project>

--- a/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
@@ -26,6 +26,14 @@ namespace Rebus.PostgreSql
         }
 
         /// <summary>
+        /// Constructs the wrapper with the given connection which should already be enlisted in a transaction.
+        /// </summary>
+        public PostgresConnection(NpgsqlConnection currentConnection)
+        {
+            _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
+        }
+
+        /// <summary>
         /// Creates a new command, enlisting it in the current transaction
         /// </summary>
         public NpgsqlCommand CreateCommand()

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -46,6 +46,9 @@
     <PackageReference Include="rebus" Version="4.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
   </ItemGroup>
+  <ItemGroup>
+	<Reference Include="System.Transactions" />
+  </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />
   </Target>


### PR DESCRIPTION
This PR enables support for ambient transactions e.g. via the built-in .net TransactionScope. It's more or less taken from https://github.com/rebus-org/Rebus.SqlServer/blob/master/Rebus.SqlServer - we need to ensure that rebus messages are only committed if the whole transaction is good, and rebus messages are just one of the transactions we need. This should enable it. 
I first tried getting https://github.com/rebus-org/Rebus.TransactionScopes to work, but that does not seem to do anything using the postgresql transport. 
These changes makes our project function as intended, but if you have a different approach we should take, let me know.

If possible, it would be awesome to get these changes into release 5.x as well as we cannot get 6.x to work with our setup. Not sure how to do that PR though. 
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
