### PR TITLE
add support for .NET 5

### DIFF
--- a/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
+++ b/Rebus.PostgreSql.Tests/Rebus.PostgreSql.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.PostgreSql.Tests</RootNamespace>
     <AssemblyName>Rebus.PostgreSql.Tests</AssemblyName>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,7 +29,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Rebus.PostgreSql\Rebus.PostgreSql.csproj" />
     <PackageReference Include="microsoft.net.test.sdk" Version="16.5.0" />
-    <PackageReference Include="npgsql" Version="4.1.3" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="nunit3testadapter" Version="3.16.1">
       <PrivateAssets>all</PrivateAssets>
@@ -38,7 +37,11 @@
     <PackageReference Include="rebus" Version="6.0.0" />
     <PackageReference Include="rebus.tests.contracts" Version="6.0.0" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="npgsql" Version="4.1.6" />
     <Reference Include="System.Transactions" />
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="npgsql" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.PostgreSql/Rebus.PostgreSql.csproj
+++ b/Rebus.PostgreSql/Rebus.PostgreSql.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus.PostgreSql</AssemblyName>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
@@ -42,12 +42,15 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="npgsql" Version="4.1.3" />
     <PackageReference Include="rebus" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.0" />
   </ItemGroup>
-  <ItemGroup>
-	<Reference Include="System.Transactions" />
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="npgsql" Version="4.1.6" />
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="npgsql" Version="5.0.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
* Add `net5.0` to the TFMs
* Introduce conditional dependency references
    + For .NET Framework 4 use _Npgsql 4.1.6_ and include reference to `System.Transactions`
    + For .NET Standard 2 and .NET 5 use _Npgsql 5.0.0_

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
