### PR TITLE
Added managedExternally property as in Rebus.SqlServer

### DIFF
--- a/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
@@ -14,15 +14,17 @@ namespace Rebus.PostgreSql
         readonly NpgsqlConnection _currentConnection;
         NpgsqlTransaction _currentTransaction;
 
+        readonly bool _managedExternally;
         bool _disposed;
 
         /// <summary>
         /// Constructs the wrapper with the given connection and transaction
         /// </summary>
-        public PostgresConnection(NpgsqlConnection currentConnection, NpgsqlTransaction currentTransaction)
+        public PostgresConnection(NpgsqlConnection currentConnection, NpgsqlTransaction currentTransaction, bool managedExternally = false)
         {
             _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
             _currentTransaction = currentTransaction ?? throw new ArgumentNullException(nameof(currentTransaction));
+            _managedExternally = managedExternally;
         }
 
         /// <summary>
@@ -49,6 +51,7 @@ namespace Rebus.PostgreSql
 
         public async Task Complete()
         {
+            if (_managedExternally) return;
             if (_currentTransaction == null) return;
             using (_currentTransaction)
             {
@@ -62,6 +65,7 @@ namespace Rebus.PostgreSql
         /// </summary>
         public void Dispose()
         {
+            if (_managedExternally) return;
             if (_disposed) return;
 
             try


### PR DESCRIPTION
Inspired by: https://github.com/rebus-org/Rebus.SqlServer/blob/master/Rebus.SqlServer/SqlServer/DbConnectionWrapper.cs#L17
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
