### PR TITLE
Added managedExternally also for no transaction constructor overload

### DIFF
--- a/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgresConnection.cs
@@ -30,9 +30,10 @@ namespace Rebus.PostgreSql
         /// <summary>
         /// Constructs the wrapper with the given connection which should already be enlisted in a transaction.
         /// </summary>
-        public PostgresConnection(NpgsqlConnection currentConnection)
+        public PostgresConnection(NpgsqlConnection currentConnection, bool managedExternally = false)
         {
             _currentConnection = currentConnection ?? throw new ArgumentNullException(nameof(currentConnection));
+            _managedExternally = managedExternally;
         }
 
         /// <summary>


### PR DESCRIPTION
I forgotten this overload because it was different than the Rebus.SQLServer
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
