### PR TITLE
Add isCentralized missing parameter to StoreInPostgres method call

### DIFF
--- a/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
@@ -115,7 +115,7 @@ public static class PostgreSqlConfigurationExtensions
     {
         var provider = new PostgresConnectionHelper(connectionString, additionalConnectionSetup);
 
-        StoreInPostgres(configurer, provider, tableName, automaticallyCreateTables);
+        StoreInPostgres(configurer, provider, tableName, isCentralized, automaticallyCreateTables);
     }
 
     /// <summary>


### PR DESCRIPTION
One parameter was omitted in StoreInPostgres method call.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
