### PR TITLE
Make saga serializer configurable

### DIFF
--- a/Rebus.PostgreSql.Tests/Sagas/PostgreSqlSagaStorageFactory.cs
+++ b/Rebus.PostgreSql.Tests/Sagas/PostgreSqlSagaStorageFactory.cs
@@ -15,7 +15,9 @@ public class PostgreSqlSagaStorageFactory : ISagaStorageFactory
 
     public ISagaStorage GetSagaStorage()
     {
-        var postgreSqlSagaStorage = new PostgreSqlSagaStorage(PostgreSqlTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false));
+        var serializer = new DefaultSagaSerializer();
+        
+        var postgreSqlSagaStorage = new PostgreSqlSagaStorage(PostgreSqlTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false), serializer);
         postgreSqlSagaStorage.EnsureTablesAreCreated();
         return postgreSqlSagaStorage;
     }

--- a/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
@@ -65,7 +65,9 @@ public static class PostgreSqlConfigurationExtensions
         configurer.Register(c =>
         {
             var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-            var sagaStorage = new PostgreSqlSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory);
+            var serializer = c.Has<ISagaSerializer>() ? c.Get<ISagaSerializer>() : new DefaultSagaSerializer();
+
+            var sagaStorage = new PostgreSqlSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory, serializer);
 
             if (automaticallyCreateTables)
             {
@@ -139,4 +141,14 @@ public static class PostgreSqlConfigurationExtensions
         });
     }
 
+    public static void UseSagaSerializer(this StandardConfigurer<ISagaStorage> configurer, ISagaSerializer serializer = null)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (serializer == null)
+        {
+            serializer = new DefaultSagaSerializer();
+        }
+
+        configurer.OtherService<ISagaSerializer>().Decorate((c) => serializer);
+    }
 }

--- a/Rebus.PostgreSql/PostgreSql/Sagas/DefaultSagaSerializer.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/DefaultSagaSerializer.cs
@@ -1,0 +1,12 @@
+using Rebus.Serialization;
+
+namespace Rebus.PostgreSql.Sagas;
+
+/// <summary>
+/// The default serializer for serializing sql saga data,
+/// Implement <seealso cref="ISagaSerializer"/> to make your own custom serializer and register it using the UseSagaSerializer extension method.
+/// <seealso cref="Rebus.Config.PostgresSagaConfigurationExtensions.UseSagaSerializer"/>
+/// </summary>
+public class DefaultSagaSerializer : ObjectSerializer, ISagaSerializer
+{
+}

--- a/Rebus.PostgreSql/PostgreSql/Sagas/ISagaSerializer.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/ISagaSerializer.cs
@@ -1,0 +1,24 @@
+namespace Rebus.PostgreSql.Sagas;
+
+public interface ISagaSerializer
+{
+    /// <summary>
+    /// Serializes the given object into a byte[]
+    /// </summary>
+    byte[] Serialize(object obj);
+
+    /// <summary>
+    /// Serializes the given object into a string
+    /// </summary>
+    string SerializeToString(object obj);
+
+    /// <summary>
+    /// Deserializes the given byte[] into an object
+    /// </summary>
+    object Deserialize(byte[] bytes);
+
+    /// <summary>
+    /// Deserializes the given string into an object
+    /// </summary>
+    object DeserializeFromString(string str);
+}

--- a/Rebus.PostgreSql/PostgreSql/Sagas/JsonSagaSerializer.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/JsonSagaSerializer.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Rebus.PostgreSql.Sagas;
+
+public class JsonSagaSerializer : ISagaSerializer
+{
+    readonly JsonSerializerSettings _settings;
+    
+    static readonly Encoding TextEncoding = Encoding.UTF8;
+
+    static readonly JsonSerializerSettings DefaultSettings = new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.All
+    };
+    
+    public JsonSagaSerializer(JsonSerializerSettings jsonSerializerSettings = null)
+    {
+        _settings = jsonSerializerSettings ?? DefaultSettings;
+    }
+    /// <summary>
+    /// Serializes the given object into a byte[]
+    /// </summary>
+    public byte[] Serialize(object obj)
+    {
+        var jsonString = SerializeToString(obj);
+
+        return TextEncoding.GetBytes(jsonString);
+    }
+
+    /// <summary>
+    /// Serializes the given object into a string
+    /// </summary>
+    public string SerializeToString(object obj)
+    {
+        return JsonConvert.SerializeObject(obj, _settings);
+    }
+
+    /// <summary>
+    /// Deserializes the given byte[] into an object
+    /// </summary>
+    public object Deserialize(byte[] bytes)
+    {
+        var jsonString = TextEncoding.GetString(bytes);
+
+        return DeserializeFromString(jsonString);
+    }
+
+    /// <summary>
+    /// Deserializes the given string into an object
+    /// </summary>
+    public object DeserializeFromString(string str)
+    {
+        try
+        {
+            return JsonConvert.DeserializeObject(str, _settings);
+        }
+        catch (Exception exception)
+        {
+            throw new JsonSerializationException($"Could not deserialize '{str}'", exception);
+        }
+    }
+}


### PR DESCRIPTION
`ObjectSerializer` is used in order to serialize saga data. Current implementation doesn't allow to provide `JsonSerializerSettings` to control the process of saga serialization. 

Such option is provided in Rebus package for MSSQL (https://github.com/rebus-org/Rebus.SqlServer/issues/59, https://github.com/rebus-org/Rebus.SqlServer/pull/77)

This PR transfers the code from the MSSQL repository into this one.

Additionaly it adds a default `JsonSagaSerializer` that allows to use `JsonSerializerSettings`.

---
I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase.
