### PR TITLE
Added  support for schemas in Postgres

### DIFF
--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -8,6 +8,7 @@ namespace Rebus.PostgreSql.Tests;
 public class PostgreSqlTestHelper
 {
     const string TableDoesNotExist = "42P01";
+    private const string SchemaDoesNotExist = "3F000";
     static readonly IPostgresConnectionProvider PostgresConnectionHelper = new PostgresConnectionHelper(ConnectionString);
 
     public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');
@@ -42,15 +43,21 @@ public class PostgreSqlTestHelper
         });
     }
 
-    public static void DropTable(string tableName)
+    public static void DropTable(string table)
+    {
+        DropTable(string.Empty, table);
+    }
+    
+    public static void DropTable(string schema, string table)
     {
         AsyncHelpers.RunSync(async () =>
         {
+            var tableName = new TableName(schema, table);
             using var connection = await PostgresConnectionHelper.GetConnection();
 
             await using var command = connection.CreateCommand();
 
-            command.CommandText = $@"drop table ""{tableName}"";";
+            command.CommandText = $"drop table {tableName};";
 
             try
             {
@@ -58,7 +65,7 @@ public class PostgreSqlTestHelper
 
                 Console.WriteLine("Dropped postgres table '{0}'", tableName);
             }
-            catch (PostgresException exception) when (exception.SqlState == TableDoesNotExist)
+            catch (PostgresException exception) when (exception.SqlState is TableDoesNotExist or SchemaDoesNotExist)
             {
             }
 

--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -8,7 +8,7 @@ namespace Rebus.PostgreSql.Tests;
 public class PostgreSqlTestHelper
 {
     const string TableDoesNotExist = "42P01";
-    private const string SchemaDoesNotExist = "3F000";
+    const string SchemaDoesNotExist = "3F000";
     static readonly IPostgresConnectionProvider PostgresConnectionHelper = new PostgresConnectionHelper(ConnectionString);
 
     public static string DatabaseName => $"rebus2_test_{TestConfig.Suffix}".TrimEnd('_');

--- a/Rebus.PostgreSql.Tests/Sagas/PostgreSqlSagaStorageFactory.cs
+++ b/Rebus.PostgreSql.Tests/Sagas/PostgreSqlSagaStorageFactory.cs
@@ -9,15 +9,15 @@ public class PostgreSqlSagaStorageFactory : ISagaStorageFactory
 {
     public PostgreSqlSagaStorageFactory()
     {
-        PostgreSqlTestHelper.DropTable("saga_index");
-        PostgreSqlTestHelper.DropTable("saga_data");
+        PostgreSqlTestHelper.DropTable("sagas", "saga_index");
+        PostgreSqlTestHelper.DropTable("sagas","saga_data");
     }
 
     public ISagaStorage GetSagaStorage()
     {
         var serializer = new DefaultSagaSerializer();
         
-        var postgreSqlSagaStorage = new PostgreSqlSagaStorage(PostgreSqlTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false), serializer);
+        var postgreSqlSagaStorage = new PostgreSqlSagaStorage(PostgreSqlTestHelper.ConnectionHelper, "saga_data", "saga_index", new ConsoleLoggerFactory(false), serializer, schemaName: "sagas");
         postgreSqlSagaStorage.EnsureTablesAreCreated();
         return postgreSqlSagaStorage;
     }

--- a/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
@@ -32,11 +32,11 @@ public static class PostgreSqlConfigurationExtensions
     /// <summary>
     /// Configures Rebus to use PostgreSql to store saga data snapshots, using the specified table to store the data
     /// </summary>
-    public static void StoreInPostgres(this StandardConfigurer<ISagaSnapshotStorage> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool automaticallyCreateTables = true)
+    public static void StoreInPostgres(this StandardConfigurer<ISagaSnapshotStorage> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool automaticallyCreateTables = true, string schemaName = null)
     {
         configurer.Register(c =>
         {
-            var sagaStorage = new PostgreSqlSagaSnapshotStorage(connectionProvider, tableName);
+            var sagaStorage = new PostgreSqlSagaSnapshotStorage(connectionProvider, tableName, schemaName);
 
             if (automaticallyCreateTables)
             {
@@ -50,24 +50,24 @@ public static class PostgreSqlConfigurationExtensions
     /// <summary>
     /// Configures Rebus to use PostgreSql to store sagas, using the tables specified to store data and indexed properties respectively.
     /// </summary>
-    public static void StoreInPostgres(this StandardConfigurer<ISagaStorage> configurer, string connectionString, string dataTableName, string indexTableName, bool automaticallyCreateTables = true, Action<NpgsqlConnection> additionalConnectionSetup = null)
+    public static void StoreInPostgres(this StandardConfigurer<ISagaStorage> configurer, string connectionString, string dataTableName, string indexTableName, bool automaticallyCreateTables = true, Action<NpgsqlConnection> additionalConnectionSetup = null, string schemaName = null)
     {
         var provider = new PostgresConnectionHelper(connectionString, additionalConnectionSetup);
             
-        StoreInPostgres(configurer, provider, dataTableName, indexTableName, automaticallyCreateTables);
+        StoreInPostgres(configurer, provider, dataTableName, indexTableName, automaticallyCreateTables, schemaName);
     }
 
     /// <summary>
     /// Configures Rebus to use PostgreSql to store sagas, using the tables specified to store data and indexed properties respectively.
     /// </summary>
-    public static void StoreInPostgres(this StandardConfigurer<ISagaStorage> configurer, IPostgresConnectionProvider connectionProvider, string dataTableName, string indexTableName, bool automaticallyCreateTables = true)
+    public static void StoreInPostgres(this StandardConfigurer<ISagaStorage> configurer, IPostgresConnectionProvider connectionProvider, string dataTableName, string indexTableName, bool automaticallyCreateTables = true, string schemaName = null)
     {
         configurer.Register(c =>
         {
             var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
             var serializer = c.Has<ISagaSerializer>() ? c.Get<ISagaSerializer>() : new DefaultSagaSerializer();
 
-            var sagaStorage = new PostgreSqlSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory, serializer);
+            var sagaStorage = new PostgreSqlSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory, serializer, schemaName);
 
             if (automaticallyCreateTables)
             {
@@ -91,13 +91,13 @@ public static class PostgreSqlConfigurationExtensions
     /// <summary>
     /// Configures Rebus to use PostgreSql to store timeouts.
     /// </summary>
-    public static void StoreInPostgres(this StandardConfigurer<ITimeoutManager> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool automaticallyCreateTables = true)
+    public static void StoreInPostgres(this StandardConfigurer<ITimeoutManager> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool automaticallyCreateTables = true, string schemaName = null)
     {
         configurer.Register(c =>
         {
             var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
             var rebusTime = c.Get<IRebusTime>();
-            var subscriptionStorage = new PostgreSqlTimeoutManager(connectionProvider, tableName, rebusLoggerFactory, rebusTime);
+            var subscriptionStorage = new PostgreSqlTimeoutManager(connectionProvider, tableName, rebusLoggerFactory, rebusTime, schemaName);
 
             if (automaticallyCreateTables)
             {
@@ -125,12 +125,12 @@ public static class PostgreSqlConfigurationExtensions
     /// subscribing and unsubscribing by manipulating the subscription directly from the subscriber or just let it default to false to preserve the
     /// default behavior.
     /// </summary>
-    public static void StoreInPostgres(this StandardConfigurer<ISubscriptionStorage> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true)
+    public static void StoreInPostgres(this StandardConfigurer<ISubscriptionStorage> configurer, IPostgresConnectionProvider connectionProvider, string tableName, bool isCentralized = false, bool automaticallyCreateTables = true, string schemaName = null)
     {
         configurer.Register(c =>
         {
             var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-            var subscriptionStorage = new PostgreSqlSubscriptionStorage(connectionProvider, tableName, isCentralized, rebusLoggerFactory);
+            var subscriptionStorage = new PostgreSqlSubscriptionStorage(connectionProvider, tableName, isCentralized, rebusLoggerFactory, schemaName);
 
             if (automaticallyCreateTables)
             {

--- a/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlTransportConfigurationExtensions.cs
@@ -57,14 +57,14 @@ public static class PostgreSqlTransportConfigurationExtensions
         OneWayClientBackdoor.ConfigureOneWayClient(configurer);
     }
 
-    static void Configure(StandardConfigurer<ITransport> configurer, IPostgresConnectionProvider connectionProvider, string tableName, string inputQueueName, TimeSpan? expiredMessagesCleanupInterval)
+    static void Configure(StandardConfigurer<ITransport> configurer, IPostgresConnectionProvider connectionProvider, string tableName, string inputQueueName, TimeSpan? expiredMessagesCleanupInterval, string schemaName = null)
     {
         configurer.Register(context =>
         {
             var rebusLoggerFactory = context.Get<IRebusLoggerFactory>();
             var asyncTaskFactory = context.Get<IAsyncTaskFactory>();
             var rebusTime = context.Get<IRebusTime>();
-            var transport = new PostgreSqlTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime, expiredMessagesCleanupInterval);
+            var transport = new PostgreSqlTransport(connectionProvider, tableName, inputQueueName, rebusLoggerFactory, asyncTaskFactory, rebusTime, expiredMessagesCleanupInterval, schemaName);
             transport.EnsureTableIsCreated();
             return transport;
         });

--- a/Rebus.PostgreSql/PostgreSql/PostgreSqlMagic.cs
+++ b/Rebus.PostgreSql/PostgreSql/PostgreSqlMagic.cs
@@ -30,12 +30,44 @@ static class PostgreSqlMagic
         
         while (reader.Read())
         {
+            var schemaName = reader["table_schema"].ToString();
             var tableName = reader["table_name"].ToString();
 
-            tableNames.Add(new TableName(tableName));
+            tableNames.Add(new TableName(schemaName, tableName));
         }
 
         return tableNames;
+    }
+    
+    public static List<string> GetSchemas(this PostgresConnection connection)
+    {
+        using var command = connection.CreateCommand();
+        return GetSchemas(command);
+    }
+
+    public static List<string> GetSchemas(this NpgsqlConnection connection, NpgsqlTransaction transaction)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        
+        return GetSchemas(command);
+    }
+
+    private static List<string> GetSchemas(NpgsqlCommand command)
+    {
+        var schemaNames = new List<string>();
+        command.CommandText = "SELECT schema_name FROM information_schema.schemata;";
+
+        using var reader = command.ExecuteReader();
+        
+        while (reader.Read())
+        {
+            var schemaName = reader["schema_name"].ToString();
+
+            schemaNames.Add(schemaName);
+        }
+
+        return schemaNames;
     }
     
     /// <summary>

--- a/Rebus.PostgreSql/PostgreSql/TableName.cs
+++ b/Rebus.PostgreSql/PostgreSql/TableName.cs
@@ -9,6 +9,11 @@ namespace Rebus.PostgreSql;
 public class TableName : IEquatable<TableName>
 {
     /// <summary>
+    /// Default schema name for postgres
+    /// </summary>
+    public const string DefaultSchemaName = "public";
+    
+    /// <summary>
     /// Gets the schema name of the table
     /// </summary>
     public string Schema { get; }
@@ -24,7 +29,7 @@ public class TableName : IEquatable<TableName>
     /// Creates a <see cref="TableName"/> object with the given schema and table names
     /// </summary>
     public TableName(string tableName)
-        : this(string.Empty, tableName)
+        : this(DefaultSchemaName, tableName)
     {
     }
     


### PR DESCRIPTION
Added support for selecting a schema for the tables that Rebus will create and use. The requested schema will also be created when not available. 

All tests are passing. One of the Saga tests is used for testing the new schema support.

This will also fix a bug that occurs when a table was not yet created in the default scheme (public), but was available in a different scheme. The table wasn't created because there was already a table with the same name. It will now check if the table with the same name is also in the same schema.

This will resolve issues #11 and #29 

I hope you like it!

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
