### PR TITLE
add TransactionScope support for outbox when not in rebus ha…

### DIFF
--- a/Rebus.PostgreSql.Tests/Outbox/TestOutbox_OutsideOfRebusHandler.cs
+++ b/Rebus.PostgreSql.Tests/Outbox/TestOutbox_OutsideOfRebusHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
 using Npgsql;
 using NUnit.Framework;
 using Rebus.Activation;
@@ -99,6 +100,44 @@ public class TestOutbox_OutsideOfRebusHandler : FixtureBase
 
     [TestCase(true, true)]
     [TestCase(false, false)]
+    public async Task CanUseOutboxOutsideOfRebusHandler_AmbientTransaction_Publish(bool commitTransaction, bool expectMessageToBeReceived)
+    {
+        var settings = new FlakySenderTransportDecoratorSettings();
+
+        using var messageWasReceived = new ManualResetEvent(initialState: false);
+        using var server = CreateConsumer("server", a => a.Handle<SomeMessage>(async _ => messageWasReceived.Set()));
+
+        await server.Subscribe<SomeMessage>();
+
+        using var client = CreateOneWayClient(flakySenderTransportDecoratorSettings: settings);
+
+        // set success rate pretty low, so we're sure that it's currently not possible to use the
+        // real transport - this is a job for the outbox! 
+        settings.SuccessRate = 0;
+
+        // pretending we're in a web app - we have these two bad boys at work:
+        using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+        { 
+            // this is how we would use the outbox for outgoing messages
+            await client.Publish(new SomeMessage());
+
+            if (commitTransaction)
+            {
+                // this is what we were all waiting for!
+                tx.Complete();
+            }
+        }
+
+        // we would not have gotten this far without the outbox - now let's pretend that the transport has recovered
+        settings.SuccessRate = 1;
+
+        // wait for server to receive the event
+        Assert.That(messageWasReceived.WaitOne(TimeSpan.FromSeconds(15)), Is.EqualTo(expectMessageToBeReceived),
+            $"When commitTransaction={commitTransaction} we {(expectMessageToBeReceived ? "expected the message to be sent and thus received" : "did NOT expect the message to be sent and therefore also not received")}");
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
     public async Task CanUseOutboxOutsideOfRebusHandler_Send(bool commitTransaction, bool expectMessageToBeReceived)
     {
         var settings = new FlakySenderTransportDecoratorSettings();
@@ -127,6 +166,41 @@ public class TestOutbox_OutsideOfRebusHandler : FixtureBase
             {
                 // this is what we were all waiting for!
                 await transaction.CommitAsync();
+            }
+        }
+
+        // we would not have gotten this far without the outbox - now let's pretend that the transport has recovered
+        settings.SuccessRate = 1;
+
+        // wait for server to receive the event
+        Assert.That(messageWasReceived.WaitOne(TimeSpan.FromSeconds(15)), Is.EqualTo(expectMessageToBeReceived),
+            $"When commitTransaction={commitTransaction} we {(expectMessageToBeReceived ? "expected the message to be sent and thus received" : "did NOT expect the message to be sent and therefore also not received")}");
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, false)]
+    public async Task CanUseOutboxOutsideOfRebusHandler_AmbientTransaction_Send(bool commitTransaction, bool expectMessageToBeReceived)
+    {
+        var settings = new FlakySenderTransportDecoratorSettings();
+
+        using var messageWasReceived = new ManualResetEvent(initialState: false);
+        using var server = CreateConsumer("server", a => a.Handle<SomeMessage>(async _ => messageWasReceived.Set()));
+        using var client = CreateOneWayClient(r => r.TypeBased().Map<SomeMessage>("server"), settings);
+
+        // set success rate pretty low, so we're sure that it's currently not possible to use the
+        // real transport - this is a job for the outbox! 
+        settings.SuccessRate = 0;
+
+        // pretending we're in a web app - we have these two bad boys at work:
+        using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+        {
+           
+            await client.Send(new SomeMessage());
+
+            if (commitTransaction)
+            {
+                // this is what we were all waiting for!
+                tx.Complete();
             }
         }
 

--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -76,6 +76,6 @@ public class PostgreSqlTestHelper
     static string GetConnectionStringForDatabase(string databaseName)
     {
         return Environment.GetEnvironmentVariable("REBUS_POSTGRES")
-               ?? $"server=localhost; database={databaseName}; user id=postgres; password=postgres;maximum pool size=30;";
+               ?? $"server=localhost; database={databaseName} user id=postgres; password=postgres;maximum pool size=30;";
     }
 }

--- a/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
+++ b/Rebus.PostgreSql.Tests/PostgreSqlTestHelper.cs
@@ -76,6 +76,6 @@ public class PostgreSqlTestHelper
     static string GetConnectionStringForDatabase(string databaseName)
     {
         return Environment.GetEnvironmentVariable("REBUS_POSTGRES")
-               ?? $"server=localhost; database={databaseName} user id=postgres; password=postgres;maximum pool size=30;";
+               ?? $"server=localhost; database={databaseName}; user id=postgres; password=postgres;maximum pool size=30;";
     }
 }

--- a/Rebus.PostgreSql/Config/Outbox/OutboxConnectionProvider.cs
+++ b/Rebus.PostgreSql/Config/Outbox/OutboxConnectionProvider.cs
@@ -31,4 +31,21 @@ class OutboxConnectionProvider : IOutboxConnectionProvider
             throw;
         }
     }
+
+    public OutboxConnection GetDbConnectionWithoutTransaction()
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+
+        try
+        {
+            connection.Open();
+
+            return new OutboxConnection(connection, null);
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
 }

--- a/Rebus.PostgreSql/Config/Outbox/SqlServerOutboxConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/Outbox/SqlServerOutboxConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using Rebus.Retry.Simple;
 using Rebus.PostgreSql.Outbox;
 using Rebus.Threading;
 using Rebus.Transport;
+using Rebus.Pipeline.Send;
 
 namespace Rebus.Config.Outbox;
 
@@ -54,6 +55,15 @@ public static class PostgreSqlOutboxConfigurationExtensions
                 var step = new OutboxIncomingStep(outboxConnectionProvider);
                 return new PipelineStepInjector(pipeline)
                     .OnReceive(step, PipelineRelativePosition.After, typeof(SimpleRetryStrategyStep));
+            });
+
+            o.Decorate<IPipeline>(c =>
+            {
+                var pipeline = c.Get<IPipeline>();
+                var outboxConnectionProvider = c.Get<IOutboxConnectionProvider>();
+                var step = new OutboxOutgoingStep(outboxConnectionProvider);
+                return new PipelineStepInjector(pipeline)
+                    .OnSend(step, PipelineRelativePosition.Before, typeof(SendOutgoingMessageStep));
             });
         });
 

--- a/Rebus.PostgreSql/PostgreSql/Outbox/IOutboxConnectionProvider.cs
+++ b/Rebus.PostgreSql/PostgreSql/Outbox/IOutboxConnectionProvider.cs
@@ -3,4 +3,5 @@
 interface IOutboxConnectionProvider
 {
     OutboxConnection GetDbConnection();
+    OutboxConnection GetDbConnectionWithoutTransaction();
 }

--- a/Rebus.PostgreSql/PostgreSql/Outbox/OutboxConnection.cs
+++ b/Rebus.PostgreSql/PostgreSql/Outbox/OutboxConnection.cs
@@ -23,6 +23,6 @@ public class OutboxConnection
     internal OutboxConnection(NpgsqlConnection connection, NpgsqlTransaction transaction)
     {
         Connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        Transaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+        Transaction = transaction;
     }
 }

--- a/Rebus.PostgreSql/PostgreSql/Outbox/OutboxOutgoingStep.cs
+++ b/Rebus.PostgreSql/PostgreSql/Outbox/OutboxOutgoingStep.cs
@@ -1,0 +1,46 @@
+﻿using Rebus.Config.Outbox;
+using Rebus.Pipeline;
+using Rebus.Transport;
+using System;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace Rebus.PostgreSql.Outbox;
+
+internal class OutboxOutgoingStep : IOutgoingStep
+{
+    private readonly IOutboxConnectionProvider _outboxConnectionProvider;
+
+    public OutboxOutgoingStep(IOutboxConnectionProvider outboxConnectionProvider)
+    {
+        _outboxConnectionProvider = outboxConnectionProvider;
+    }
+
+    public Task Process(OutgoingStepContext context, Func<Task> next)
+    {
+        var transactionContext = context.Load<ITransactionContext>();
+
+        //in Rebus handler context, outbox is initialized by Incomming step
+        //not in Rebus handler context and a rebus outbox transaction is explicitly (UseOutbox) created and outbox is initialized
+        if (transactionContext.Items.ContainsKey(OutboxExtensions.CurrentOutboxConnectionKey))
+        {
+            //all is done
+            return next();
+        }
+
+        //if an ambient transaction exists, create an oubox connection without transaction to connection enroll in current transaction
+        if (Transaction.Current != null)
+        {
+            var outboxConnection = _outboxConnectionProvider.GetDbConnectionWithoutTransaction();
+            transactionContext.Items[OutboxExtensions.CurrentOutboxConnectionKey] = outboxConnection;
+
+            transactionContext.OnDisposed(_ =>
+            {
+                outboxConnection.Connection.Dispose();
+            });
+        }
+
+        return next();
+    }
+}
+

--- a/Rebus.PostgreSql/PostgreSql/Outbox/PostgreSqlOutboxStorage.cs
+++ b/Rebus.PostgreSql/PostgreSql/Outbox/PostgreSqlOutboxStorage.cs
@@ -215,7 +215,7 @@ CREATE TABLE {_tableName}
             command.CommandText = $@"
 SELECT ""Id"", ""DestinationAddress"", ""Headers"", ""Body""
 FROM {_tableName} WITH (UPDLOCK, READPAST)
-WHERE ""CorrelationId"" = @correlationId ""Sent"" = false
+WHERE ""CorrelationId"" = @correlationId AND ""Sent"" = false
 ORDER BY ""Id""
 FOR UPDATE SKIP LOCKED
 LIMIT {maxMessageBatchSize}";


### PR DESCRIPTION
…ndler

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
