### PR TITLE
Use now() instead of clock_timestamp() to allow better index on cleanup deletes

### DIFF
--- a/Rebus.PostgreSql.Tests/docker-compose.yml
+++ b/Rebus.PostgreSql.Tests/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.6'
+
+services:
+  db:
+    image: postgres
+    ports:
+      - 5432:5432
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all 
+    environment:
+      POSTGRES_USER: postgres # The PostgreSQL user (useful to connect to the database)
+      POSTGRES_PASSWORD: postgres # The PostgreSQL password (useful to connect to the database)
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8081:8080
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - 8082:80
+    environment:
+      PGADMIN_DEFAULT_EMAIL: test@mailinator.com # The PostgreSQL user (useful to connect to the database)
+      PGADMIN_DEFAULT_PASSWORD: postgres # The PostgreSQL password (useful to connect to the database)

--- a/Rebus.PostgreSql/PostgreSql/Transport/PostgresqlTransport.cs
+++ b/Rebus.PostgreSql/PostgreSql/Transport/PostgresqlTransport.cs
@@ -126,8 +126,8 @@ VALUES
     @headers,
     @body,
     @priority,
-    clock_timestamp() + @visible,
-    clock_timestamp() + @ttlseconds
+    now() + @visible,
+    now() + @ttlseconds
 )";
 
             var headers = message.Headers.Clone();
@@ -173,8 +173,8 @@ where id =
 (
     select id from {_tableName}
     where recipient = @recipient
-    and visible < clock_timestamp()
-    and expiration > clock_timestamp() 
+    and visible < now()
+    and expiration > now() 
     order by priority desc, visible asc, id asc
     for update skip locked
     limit 1
@@ -219,7 +219,7 @@ body
                     command.CommandText =
                         $@"
                 delete from {_tableName} 
-                where expiration < clock_timestamp()
+                where expiration < now()
 ";
                     affectedRows = await command.ExecuteNonQueryAsync();
                 }
@@ -319,6 +319,11 @@ CREATE INDEX ""idx_dequeue_{_tableName.Name}"" ON {_tableName}
     priority DESC,
     visible ASC,
     id ASC
+);
+----
+CREATE INDEX ""idx_expiration_{_tableName.Name}"" ON {_tableName}
+(
+ expiration
 );
 ");
 


### PR DESCRIPTION
Addresses https://github.com/rebus-org/Rebus.PostgreSql/issues/38#issue-1666625600

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
