### PR TITLE
Fix issue where UseSagaSerializer ignores the passed custom ISagaSeri…

### DIFF
--- a/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
+++ b/Rebus.PostgreSql/Config/PostgreSqlConfigurationExtensions.cs
@@ -65,7 +65,7 @@ public static class PostgreSqlConfigurationExtensions
         configurer.Register(c =>
         {
             var rebusLoggerFactory = c.Get<IRebusLoggerFactory>();
-            var serializer = c.Has<ISagaSerializer>() ? c.Get<ISagaSerializer>() : new DefaultSagaSerializer();
+            var serializer = c.Has<ISagaSerializer>(false) ? c.Get<ISagaSerializer>() : new DefaultSagaSerializer();
 
             var sagaStorage = new PostgreSqlSagaStorage(connectionProvider, dataTableName, indexTableName, rebusLoggerFactory, serializer, schemaName);
 


### PR DESCRIPTION
…alizer

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
