### PR TITLE
Could not find existing saga data when the assembly version changes

### DIFF
--- a/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaStorage.cs
+++ b/Rebus.PostgreSql/PostgreSql/Sagas/PostgreSqlSagaStorage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 // ReSharper disable once RedundantUsingDirective (because .NET Core)
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Npgsql;
 using NpgsqlTypes;
@@ -413,7 +414,15 @@ INSERT
 
     string GetSagaTypeName(Type sagaDataType)
     {
-        return sagaDataType.FullName;
+        return _removeVersionFromTypeFullName();
+
+        // Rebus cannot find existing saga when the version changes, which breaks a long-running saga with deployments during the saga lifetime.
+        string _removeVersionFromTypeFullName()
+        {
+            return sagaDataType.FullName != null 
+                ? Regex.Replace(sagaDataType.FullName, @"Version=\d+\.\d+\.\d+\.\d+, ", "")
+                : null;
+        }
     }
 
     static List<KeyValuePair<string, string>> GetPropertiesToIndex(ISagaData sagaData, IEnumerable<ISagaCorrelationProperty> correlationProperties)


### PR DESCRIPTION
Removing assembly version from persisted saga type (column saga_type). It then allows deployments with changes assembly version during long-running saga. 